### PR TITLE
fix: Remove unnecessary list on extract_translations

### DIFF
--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -455,9 +455,9 @@ extract_translations(Tokens) ->
     lists:foldl(
         fun
             ({trans_text, LineAndNumber, Text}, Acc) ->
-                [ {template_compiler_utils:unescape_string_literal(Text), [], [LineAndNumber]} | Acc ];
+                [ {template_compiler_utils:unescape_string_literal(Text), [], LineAndNumber} | Acc ];
             ({trans_literal, LineAndNumber, Text}, Acc) ->
-                [ {template_compiler_utils:unescape_string_literal(Text), [], [LineAndNumber]} | Acc ];
+                [ {template_compiler_utils:unescape_string_literal(Text), [], LineAndNumber} | Acc ];
             (_Token, Acc) ->
                 Acc
         end,


### PR DESCRIPTION
It's not necessary to add the variable LineAndNumber to a list. If the same translation text is repeated on the same file the template_compiler will create two distinct tuples on extract_translations.