### PR TITLE
Add support for 'image_data_url' tag.

### DIFF
--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -55,6 +55,7 @@
 
 -type builtin_tag() :: image
                      | image_url
+                     | image_data_url
                      | media
                      | url
                      | lib.

--- a/src/template_compiler_element.erl
+++ b/src/template_compiler_element.erl
@@ -232,7 +232,11 @@ compile({custom_tag, {identifier, SrcPos, Name}, Args}, #cs{runtime=Runtime} = C
             {context, erl_syntax:variable(CState#cs.context_var)}
         ]),
     {Ws1, Ast};
-compile({Tag, {_, SrcPos, _}, Expr, Args}, #cs{runtime=Runtime} = CState, Ws) when Tag =:= image; Tag =:= image_url; Tag =:= media ->
+compile({Tag, {_, SrcPos, _}, Expr, Args}, #cs{runtime=Runtime} = CState, Ws)
+    when Tag =:= image;
+         Tag =:= image_url;
+         Tag =:= image_data_url;
+         Tag =:= media ->
     {Ws1, ArgsList} = with_args(Args, CState, Ws, false),
     {Ws2, ExprAst} = template_compiler_expr:compile(Expr, CState, Ws1),
     ArgsListAst = erl_syntax:list([ erl_syntax:tuple([A,B]) || {A,B} <- ArgsList ]),

--- a/src/template_compiler_parser.yrl
+++ b/src/template_compiler_parser.yrl
@@ -140,6 +140,7 @@ Nonterminals
     PrintTag
     ImageTag
     ImageUrlTag
+    ImageDataUrlTag
     MediaTag
     TransTag
     TransExtTag
@@ -197,6 +198,7 @@ Terminals
     ifnotequal_keyword
     image_keyword
     image_url_keyword
+    image_data_url_keyword
     in_keyword
     include_keyword
     inherit_keyword
@@ -297,6 +299,7 @@ Elements -> Elements UrlTag : '$1' ++ ['$2'].
 Elements -> Elements PrintTag : '$1' ++ ['$2'].
 Elements -> Elements ImageTag : '$1' ++ ['$2'].
 Elements -> Elements ImageUrlTag : '$1' ++ ['$2'].
+Elements -> Elements ImageDataUrlTag : '$1' ++ ['$2'].
 Elements -> Elements MediaTag : '$1' ++ ['$2'].
 
 
@@ -431,6 +434,7 @@ CallWithTag -> open_tag call_keyword identifier with_keyword E close_tag : {call
 
 ImageTag -> open_tag image_keyword E Args close_tag : {image, '$2', '$3', '$4' }.
 ImageUrlTag -> open_tag image_url_keyword E Args close_tag : {image_url, '$2', '$3', '$4' }.
+ImageDataUrlTag -> open_tag image_data_url_keyword E Args close_tag : {image_data_url, '$2', '$3', '$4' }.
 MediaTag -> open_tag media_keyword E Args close_tag : {media, '$2', '$3', '$4' }.
 
 UrlTag -> open_tag url_keyword E Args close_tag : {url, '$2', '$3', '$4'}.

--- a/src/template_compiler_runtime.erl
+++ b/src/template_compiler_runtime.erl
@@ -286,7 +286,8 @@ custom_tag(Tag, Args, Vars, Context) ->
     Tag:render(Args, Vars, Context).
 
 
-%% @doc Render image/image_url/media/url/lib/lib_url tag. The Expr is the media item or dispatch rule.
+%% @doc Render image/image_url/image_data_url/media/url/lib/lib_url tag.
+%%      The Expr is the media item or dispatch rule.
 -spec builtin_tag(template_compiler:builtin_tag(), Expr::term(), Args::list(), Vars::map(), Context::term()) -> 
             template_compiler:render_result().
 builtin_tag(_Tag, _Expr, _Args, _Vars, _Context) ->

--- a/src/template_compiler_scanner.erl
+++ b/src/template_compiler_scanner.erl
@@ -1,7 +1,8 @@
 %%%-------------------------------------------------------------------
 %%% @author    Roberto Saccon <rsaccon@gmail.com> [http://rsaccon.com]
 %%% @author    Evan Miller <emmiller@gmail.com>
-%%% @copyright 2008 Roberto Saccon, Evan Miller
+%%% @author    Marc Worrell <marc@worrell.nl>
+%%% @copyright 2008 Roberto Saccon, Evan Miller; 2009-2020 Marc Worrell
 %%% @doc 
 %%% Template language scanner
 %%% @end  
@@ -9,6 +10,7 @@
 %%% The MIT License
 %%%
 %%% Copyright (c) 2007 Roberto Saccon, Evan Miller
+%%% Copyright (c) 2009-2020 Marc Worrell
 %%%
 %%% Permission is hereby granted, free of charge, to any person obtaining a copy
 %%% of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +31,7 @@
 %%% THE SOFTWARE.
 %%%
 %%% @since 2007-11-11 by Roberto Saccon, Evan Miller
+%%% @since 2008 by Marc Worrell
 %%%-------------------------------------------------------------------
 %%%
 %%%-------------------------------------------------------------------
@@ -79,8 +82,10 @@ identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc})
         <<"comment">>, <<"endcomment">>, <<"cycle">>, <<"firstof">>, <<"ifchanged">>,
         <<"ifequal">>, <<"endifequal">>, <<"ifnotequal">>, <<"endifnotequal">>, <<"now">>,
         <<"regroup">>, <<"rsc">>, <<"spaceless">>, <<"endspaceless">>, <<"ssi">>,
-        <<"templatetag">>, <<"load">>, <<"call">>, <<"url">>, <<"print">>, <<"image">>,
-        <<"image_url">>, <<"media">>, <<"with">>, <<"endwith">>, <<"all">>, <<"lib">>, <<"lib_url">>,
+        <<"templatetag">>, <<"load">>, <<"call">>, <<"url">>, <<"print">>,
+        <<"image">>, <<"image_url">>, <<"image_data_url">>, <<"media">>,
+        <<"with">>, <<"endwith">>, <<"all">>,
+        <<"lib">>, <<"lib_url">>,
         <<"cache">>, <<"endcache">>, <<"filter">>, <<"endfilter">>, <<"javascript">>,
         <<"endjavascript">>, <<"optional">>, <<"trans">>
     ],


### PR DESCRIPTION
Add support for the `{% image_data_url ... %}` tag.
This is similar to the `image_url` tag, except that a `data:` url is generated.

This is added to support https://github.com/zotonic/zotonic/issues/1759