### PR TITLE
Binary vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ How to use
 
 Render a template to an iolist:
 
-    Vars = #{ a => 1 },                 % Template variables, use a map
+    Vars = #{ <<"a">> => 1 },                 % Template variables, use a map
     Options = [],                       % Render and compilation options
     Context = your_request_context,     % Context passed to the runtime module and filters
     {ok, IOList} = template_compiler:render("hello.tpl", Vars, Options, Context).
@@ -175,11 +175,11 @@ Instead of strings, variables can also be objects that contain attributes. To ac
 The `article` could have been passed as a proplist or map in the _Vars_ for the template render function:
 
     #{
-        article => #{
-            title => <<"My title"/utf8>>,
-            author => #{
-                id => 1234,
-                last_name => <<"Janssen">>
+        <<"article">> => #{
+            <<"title">> => <<"My title"/utf8>>,
+            <<"author">> => #{
+                <<"id">> => 1234,
+                <<"last_name">> => <<"Janssen">>
             }
         }
     }.

--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -86,7 +86,7 @@ compile_file(Filename, TplKey, Options, Context) ->
                         ?WITH_STACKTRACE(What, Error, Stack)
                             % io:format("Error compiling template ~p: ~p:~n~p at~n ~p~n",
                             %           [Filename, What, Error, Stack]),
-                            io:format("Error compiling template ~p: ~p:~n~p at~n ~p~n",
+                            lager:error("Error compiling template ~p: ~p:~n~p at~n ~p~n",
                                         [Filename, What, Error,
                                          lager:pr_stacktrace(Stack, {What, Error})
                                         ]),

--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -86,7 +86,7 @@ compile_file(Filename, TplKey, Options, Context) ->
                         ?WITH_STACKTRACE(What, Error, Stack)
                             % io:format("Error compiling template ~p: ~p:~n~p at~n ~p~n",
                             %           [Filename, What, Error, Stack]),
-                            lager:error("Error compiling template ~p: ~p:~n~p at~n ~p~n",
+                            io:format("Error compiling template ~p: ~p:~n~p at~n ~p~n",
                                         [Filename, What, Error,
                                          lager:pr_stacktrace(Stack, {What, Error})
                                         ]),

--- a/src/template_compiler_expr.erl
+++ b/src/template_compiler_expr.erl
@@ -192,7 +192,7 @@ find_value_lookup([{_, SrcPos, _}|_] = ValueLookup, #cs{runtime=Runtime, vars_va
                         {vars, erl_syntax:variable(Vars)},
                         {context, erl_syntax:variable(CState#cs.context_var)}
                     ]),
-            {maybe_forloop_var(Ws3, hd(ValueLookup)), Ast};
+            {Ws3, Ast};
         [{mfa2, M, F, As, ExtraArg}] ->
             {Ws1, ValueLookupAsts} = value_lookup_asts(As, CState, Ws, []),
             {Ws2, V1} = template_compiler_utils:var(Ws1),
@@ -216,9 +216,9 @@ find_value_lookup([{_, SrcPos, _}|_] = ValueLookup, #cs{runtime=Runtime, vars_va
                         {vars, erl_syntax:variable(Vars)},
                         {context, erl_syntax:variable(CState#cs.context_var)}
                     ]),
-            {maybe_forloop_var(Ws3, hd(ValueLookup)), Ast};
+            {Ws3, Ast};
         [{ast, Ast}] ->
-            {maybe_forloop_var(Ws, hd(ValueLookup)), Ast};
+            {Ws, Ast};
         [{ast, Ast} | ValueLookup1 ] ->
             {Ws1, ValueLookupAsts} = value_lookup_asts(ValueLookup1, CState, Ws, []),
             Ast1 = merl:qquote(
@@ -230,8 +230,8 @@ find_value_lookup([{_, SrcPos, _}|_] = ValueLookup, #cs{runtime=Runtime, vars_va
                         {vars, Ast},
                         {context, erl_syntax:variable(CState#cs.context_var)}
                     ]),
-            {maybe_forloop_var(Ws1, hd(ValueLookup)), Ast1};
-        [{identifier, SrcPos, Var} = Idn] = ValueLookup ->
+            {Ws1, Ast1};
+        [{identifier, SrcPos, Var}] = ValueLookup ->
             VarName = template_compiler_utils:to_atom(Var),
             Ast = merl:qquote(
                     template_compiler_utils:pos(SrcPos),
@@ -242,7 +242,7 @@ find_value_lookup([{_, SrcPos, _}|_] = ValueLookup, #cs{runtime=Runtime, vars_va
                         {vars, erl_syntax:variable(Vars)},
                         {context, erl_syntax:variable(CState#cs.context_var)}
                     ]),
-            {maybe_forloop_var(Ws, Idn), Ast};
+            {Ws, Ast};
         ValueLookup1 ->
             {Ws1, ValueLookupAsts} = value_lookup_asts(ValueLookup1, CState, Ws, []),
             Ast = merl:qquote(
@@ -254,13 +254,8 @@ find_value_lookup([{_, SrcPos, _}|_] = ValueLookup, #cs{runtime=Runtime, vars_va
                         {vars, erl_syntax:variable(Vars)},
                         {context, erl_syntax:variable(CState#cs.context_var)}
                     ]),
-            {maybe_forloop_var(Ws1, hd(ValueLookup)), Ast}
+            {Ws1, Ast}
     end.
-
-maybe_forloop_var(Ws, {identifier, _, <<"forloop">>}) ->
-    Ws#ws{is_forloop_var=true};
-maybe_forloop_var(Ws, _) ->
-    Ws.
 
 value_lookup_asts([], _CState, Ws, Acc) ->
     {Ws, lists:reverse(Acc)};


### PR DESCRIPTION
Make the var lookup in sequences like `a.b.c` binaries instead of atoms.

This to be more compatible with maps that have binary keys (like JSON etc).