### PR TITLE
Fix typo for lib_url atom

### DIFF
--- a/src/template_compiler_parser.yrl
+++ b/src/template_compiler_parser.yrl
@@ -331,7 +331,7 @@ OptionalAll -> all_keyword : all.
 OptionalAll -> '$empty' : normal.
 
 LibTag -> open_tag lib_keyword LibList Args close_tag : {lib, '$2', '$3', '$4'}.
-LibUrlTag -> open_tag lib_url_keyword LibList Args close_tag : {lib, '$2', '$3', '$4'}.
+LibUrlTag -> open_tag lib_url_keyword LibList Args close_tag : {lib_url, '$2', '$3', '$4'}.
 LibList -> string_literal : ['$1'].
 LibList -> LibList string_literal : '$1' ++ ['$2'].
 


### PR DESCRIPTION
There was a typo which caused `lib_url` tags to be handled as `lib` tags.