### PR TITLE
Remove the tpl key from the waiters tuple in reply

### DIFF
--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -163,7 +163,7 @@ handle_call({compile_done, Result, TplKey}, _From, State) ->
     end,
     {Waiters, State2} = split_waiters(TplKey, State1),
     lists:foreach(
-            fun(Waiter) ->
+            fun({_TplKey, Waiter}) ->
                 gen_server:reply(Waiter, Result)
             end,
             Waiters),


### PR DESCRIPTION
`gen_server:reply/2` was called with the wrong parameters.

Fixes #19 