### PR TITLE
For loop: handle map different depending on the number of keys.

### DIFF
--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -1,8 +1,8 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2016-2021 Marc Worrell
+%% @copyright 2016-2022 Marc Worrell
 %% @doc Callback routines for compiled templates.
 
-%% Copyright 2016-2021 Marc Worrell
+%% Copyright 2016-2022 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@
     unique/0
     ]).
 
--include("template_compiler.hrl").
 
 %% @doc Runtime implementation of a forloop. Two variations: one with 
 -spec forloop(IsForloopVar :: boolean(), ListExpr :: term(), LoopVars :: [atom()],
@@ -38,7 +37,7 @@
               Runtime :: atom(), IsContextVars :: boolean(),
               Vars :: map(), Context :: term()) -> term().
 forloop(IsLoopVar, ListExpr, Idents, BodyFun, EmptyFun, Runtime, IsContextVars, Vars, Context) ->
-    case Runtime:to_list(ListExpr, Context) of
+    case forloop_to_list(ListExpr, length(Idents), Runtime, Context) of
         [] ->
             EmptyFun();
         List when IsLoopVar ->
@@ -46,6 +45,12 @@ forloop(IsLoopVar, ListExpr, Idents, BodyFun, EmptyFun, Runtime, IsContextVars, 
         List when not IsLoopVar ->
             forloop_map(List, Idents, BodyFun, Runtime, IsContextVars, Vars, Context)
     end.
+
+forloop_to_list(Map, 1, _Runtime, _Context) when is_map(Map) ->
+    [ Map ];
+forloop_to_list(ListExpr, _NVars, Runtime, Context) ->
+    Runtime:to_list(ListExpr, Context).
+
 
 % For loop with a forloop variable in the body, use a fold with a forloop state
 % variable.

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -46,8 +46,12 @@ forloop(IsLoopVar, ListExpr, Idents, BodyFun, EmptyFun, Runtime, IsContextVars, 
             forloop_map(List, Idents, BodyFun, Runtime, IsContextVars, Vars, Context)
     end.
 
-forloop_to_list(Map, 1, _Runtime, _Context) when is_map(Map) ->
-    [ Map ];
+forloop_to_list(V, 1, _Runtime, _Context)
+    when is_map(V);
+         is_number(V);
+         is_atom(V);
+         is_binary(V) ->
+    [ V ];
 forloop_to_list(ListExpr, _NVars, Runtime, Context) ->
     Runtime:to_list(ListExpr, Context).
 

--- a/test/template_compiler_control_flow_SUITE.erl
+++ b/test/template_compiler_control_flow_SUITE.erl
@@ -26,6 +26,7 @@ groups() ->
         ,for_test
         ,for_forloop_test
         ,for_multivar_test
+        ,for_map_test
         ]}].
 
 init_per_suite(Config) ->
@@ -103,6 +104,18 @@ for_multivar_test(_Config) ->
     {ok, Bin1} = template_compiler:render("for_multivar.tpl", #{ v => [{a,1},{b,2},{c,3}] }, [], undefined),
     <<"a:1,b:2,c:3,">> = z_string:trim(iolist_to_binary(Bin1)),
     ok.
+
+for_map_test(_Config) ->
+    % for v in map - a single map becomes a list
+    {ok, Bin1} = template_compiler:render("for_map_1.tpl", #{ v => #{ foo => 1 } }, [], undefined),
+    <<"1">> = z_string:trim(iolist_to_binary(Bin1)),
+    {ok, Bin2} = template_compiler:render("for_map_1.tpl", #{ v => [ #{ foo => 1 } ] }, [], undefined),
+    <<"1">> = z_string:trim(iolist_to_binary(Bin2)),
+    % for k,v in map - access the map as key/value list
+    {ok, Bin3} = template_compiler:render("for_map_2.tpl", #{ v => #{ foo => 1 } }, [], undefined),
+    <<"foo,1">> = z_string:trim(iolist_to_binary(Bin3)),
+    ok.
+
 
 test_data_dir(Config) ->
     filename:join([

--- a/test/test-data/for_map_1.tpl
+++ b/test/test-data/for_map_1.tpl
@@ -1,0 +1,1 @@
+{% for n in v %}{{ n.foo }}{% endfor %}

--- a/test/test-data/for_map_2.tpl
+++ b/test/test-data/for_map_2.tpl
@@ -1,0 +1,1 @@
+{% for k,n in v %}{{ k }},{{ n }}{% endfor %}


### PR DESCRIPTION
This makes handling a for loop through a map different, but more consistent with the `.`-lookups.

If we have these variables:

```erlang
#{
   a => #{ foo => 1 },
   b => [ #{ foo => 1 } ]
}
```

Then the lookups ``a[1].foo``, ``b[1].foo``, ``a.foo`` and ``b.foo`` all return the value ``1``.

With this change the for loop:

```django
{% for k,v in a %}{{ k }}:{{ v }}{% endfor %}
```

and 

```django
{% for k,v in b %}{{ k }}:{{ v }}{% endfor %}
```

Will both output ``foo:1``.

Where :

```django
{% for k in a %}{{ k.foo }}{% endfor %}
```

and 

```django
{% for k in b %}{{ k.foo }}{% endfor %}
```

will both output ``1``.

