### PR TITLE
Remove compat with pre OTP 22

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,17 +1,12 @@
 {require_min_otp_vsn, "22"}.
 
 {erl_opts, [
-  debug_info,
-
-  {platform_define, "^[0-9]+", namespaced_dicts},
-  {platform_define, "^(19|2)", rand_only},
-  {platform_define, "^(R|1|20)", fun_stacktrace}
- ]
-}.
+    debug_info
+]}.
 
 {deps, [
-  {erlang_localtime, "1.0.0"},
-  {zotonic_stdlib, "1.5.3"}
+    {erlang_localtime, "1.0.0"},
+    {zotonic_stdlib, "1.6.0"}
 ]}.
 
 {xref_checks, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,19 +2,21 @@
 [{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.11.0">>},1},
  {<<"erlang_localtime">>,{pkg,<<"erlang_localtime">>,<<"1.0.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},2},
- {<<"tls_certificate_check">>,{pkg,<<"tls_certificate_check">>,<<"1.8.0">>},1},
- {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.5.3">>},0}]}.
+ {<<"tls_certificate_check">>,
+  {pkg,<<"tls_certificate_check">>,<<"1.11.0">>},
+  1},
+ {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.6.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"cowlib">>, <<"0B9FF9C346629256C42EBE1EEB769A83C6CB771A6EE5960BD110AB0B9B872063">>},
  {<<"erlang_localtime">>, <<"497DFD4D13523D3E0EECDCB8D6D59857CF642A17A6BDC6133FF906FDAF2AEF21">>},
  {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
- {<<"tls_certificate_check">>, <<"8A41A435C8055CB11D1D0AC96B34F48377D49FEA2782D70EABCF8946539946A3">>},
- {<<"zotonic_stdlib">>, <<"0B02BEFE4728FCC7D8905C9219AB2BA1EEE93A0C9BC67B87647385868EBEE1F8">>}]},
+ {<<"tls_certificate_check">>, <<"609DCD503F31170F0799DAC380EB0E086388CF918FC769AAA60DDD6BBF575218">>},
+ {<<"zotonic_stdlib">>, <<"872E85BD2DC8A49A4DA255E4DF6C1B4DDC993E59024D02303BD6A5DF0868859B">>}]},
 {pkg_hash_ext,[
  {<<"cowlib">>, <<"2B3E9DA0B21C4565751A6D4901C20D1B4CC25CBB7FD50D91D2AB6DD287BC86A9">>},
  {<<"erlang_localtime">>, <<"46E3F7B18477B377EC71F9DCD91C4D30FE82A128FFA9F89BE1595D4D08414844">>},
  {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
- {<<"tls_certificate_check">>, <<"5211FD87B4FEFAA77F2DE1F03479CBC4EE8312738A21B9B905253674468928F2">>},
- {<<"zotonic_stdlib">>, <<"302B4F69991E8AFE3D3AD8E09E26EC01072BF082AC6D65656D2B00CC1A41CF35">>}]}
+ {<<"tls_certificate_check">>, <<"4AB962212EF7C87482619CB298E1FE06E047B57F0BD58CC417B3B299EB8D036E">>},
+ {<<"zotonic_stdlib">>, <<"9139167866615F226C3915B6082B317892E276F3A9C78C5A99CD497FA589444E">>}]}
 ].

--- a/src/template_compiler_internal.hrl
+++ b/src/template_compiler_internal.hrl
@@ -61,10 +61,3 @@
         is_autoescape = false :: boolean()
     }).
 
-
--ifdef(fun_stacktrace).
--define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).
--else.
--define(WITH_STACKTRACE(T, R, S), T:R:S ->).
--endif.
-

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -267,10 +267,5 @@ unique() ->
     <<"u", (integer_to_binary(rand_uniform(100000000000000000), 36))/binary>>.
 
 -spec rand_uniform( pos_integer() ) -> non_neg_integer().
--ifdef(rand_only).
 rand_uniform(N) ->
     rand:uniform(N) - 1.
--else.
-rand_uniform(N) ->
-    crypto:rand_uniform(0,N).
--endif.


### PR DESCRIPTION
Removes the macro's for rand_only, fun_stacktrace and namespaces_dicts.

Upgrade zotonic_stdlib.