### PR TITLE
Use structured logging

### DIFF
--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -196,7 +196,7 @@ block_lookup({ok, TplFile}, BlockMap, ExtendsStack, DebugTrace, Options, Vars, R
             case lists:member(Module, ExtendsStack) of
                 true ->
                     FileTrace = [Module:filename() | [ M:filename() || M <- ExtendsStack ]],
-                    ?LOG_ERROR("[template_compiler] Template recursion: ~p", [FileTrace]),
+                    ?LOG_ERROR(#{ text => "Template recursion.", trace => FileTrace}),
                     {error, {recursion, [Trace|DebugTrace]}};
                 false ->
                     % Check extended/overruled templates (build block map)
@@ -355,16 +355,14 @@ compile_forms(Filename, Forms) ->
                 {module, _Module} ->
                     {ok, Module};
                 Error ->
-                    ?LOG_ERROR("Error loading compiling forms for ~p: ~p",
-                                [Filename, Error]),
+                    ?LOG_ERROR(#{ text => "Error loading compiling forms.", filename => Filename, error => Error}),
                     Error
             end;
         error ->
-            ?LOG_ERROR("Error compiling forms for ~p", [Filename]),
+            ?LOG_ERROR(#{ text => "Error compiling forms.", filename => Filename}),
             {error, {compile, []}};
         {error, Es, Ws} ->
-            ?LOG_ERROR("Errors compiling ~p: ~p  (warnings ~p)",
-                        [Filename, Es, Ws]),
+            ?LOG_ERROR(#{ text => "Errors compiling.", filename => Filename, errors => Es, warnings => Ws}),
             {error, {compile, Es, Ws}}
     end.
 

--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -196,7 +196,7 @@ block_lookup({ok, TplFile}, BlockMap, ExtendsStack, DebugTrace, Options, Vars, R
             case lists:member(Module, ExtendsStack) of
                 true ->
                     FileTrace = [Module:filename() | [ M:filename() || M <- ExtendsStack ]],
-                    ?LOG_ERROR(#{ text => "Template recursion.", trace => FileTrace}),
+                    ?LOG_ERROR(#{ text => "Template recursion.", trace => FileTrace }),
                     {error, {recursion, [Trace|DebugTrace]}};
                 false ->
                     % Check extended/overruled templates (build block map)

--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -362,7 +362,7 @@ compile_forms(Filename, Forms) ->
             ?LOG_ERROR(#{ text => "Error compiling forms.", filename => Filename }),
             {error, {compile, []}};
         {error, Es, Ws} ->
-            ?LOG_ERROR(#{ text => "Errors compiling.", filename => Filename, errors => Es, warnings => Ws}),
+            ?LOG_ERROR(#{ text => "Errors compiling.", filename => Filename, errors => Es, warnings => Ws }),
             {error, {compile, Es, Ws}}
     end.
 

--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -359,7 +359,7 @@ compile_forms(Filename, Forms) ->
                     Error
             end;
         error ->
-            ?LOG_ERROR(#{ text => "Error compiling forms.", filename => Filename}),
+            ?LOG_ERROR(#{ text => "Error compiling forms.", filename => Filename }),
             {error, {compile, []}};
         {error, Es, Ws} ->
             ?LOG_ERROR(#{ text => "Errors compiling.", filename => Filename, errors => Es, warnings => Ws}),

--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -355,7 +355,7 @@ compile_forms(Filename, Forms) ->
                 {module, _Module} ->
                     {ok, Module};
                 Error ->
-                    ?LOG_ERROR(#{ text => "Error loading compiling forms.", filename => Filename, error => Error}),
+                    ?LOG_ERROR(#{ text => "Error loading compiling forms.", filename => Filename, error => Error }),
                     Error
             end;
         error ->

--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -221,7 +221,7 @@ handle_cast(Msg, State) ->
 handle_info({'DOWN', MRef, process, _Pid, Reason}, State) ->
     case lists:keytake(MRef, 1, State#state.compiling) of
         {value, {_MRef, TplKey, _From}, Compiling1} ->
-            ?LOG_ERROR(#{ text => "Process compiling down. Restarting other waiter.", tpl_key => TplKey, reason => Reason}),
+            ?LOG_ERROR(#{ text => "Process compiling down. Restarting other waiter.", tpl_key => TplKey, reason => Reason }),
             {noreply, restart_compile(TplKey, State#state{compiling=Compiling1})};
         false ->
             {noreply, State}

--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -88,7 +88,7 @@ compile_file(Filename, TplKey, Options, Context) ->
                             %           [Filename, What, Error, Stack]),
                             ?LOG_ERROR(
                                 #{
-                                  text =>"Error compiling template.", 
+                                  text => "Error compiling template.", 
                                   template => Filename,
                                   what => What,
                                   error => Error,

--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -87,11 +87,12 @@ compile_file(Filename, TplKey, Options, Context) ->
                             % io:format("Error compiling template ~p: ~p:~n~p at~n ~p~n",
                             %           [Filename, What, Error, Stack]),
                             ?LOG_ERROR(
-                                "Error compiling template ~p: ~p: ~p",
-                                [Filename, What, Error],
                                 #{
-                                    template => Filename,
-                                    stack => Stack
+                                  text =>"Error compiling template.", 
+                                  template => Filename,
+                                  what => What,
+                                  error => Error,
+                                  stack => Stack
                                 }),
                             {error, Error}
                      end,
@@ -220,8 +221,7 @@ handle_cast(Msg, State) ->
 handle_info({'DOWN', MRef, process, _Pid, Reason}, State) ->
     case lists:keytake(MRef, 1, State#state.compiling) of
         {value, {_MRef, TplKey, _From}, Compiling1} ->
-            ?LOG_ERROR("[template_compiler] Process compiling ~p down (reason ~p), restarting other waiter",
-                        [TplKey, Reason]),
+            ?LOG_ERROR(#{ text => "Process compiling down. Restarting other waiter.", tpl_key => TplKey, reason => Reason}),
             {noreply, restart_compile(TplKey, State#state{compiling=Compiling1})};
         false ->
             {noreply, State}

--- a/src/template_compiler_runtime.erl
+++ b/src/template_compiler_runtime.erl
@@ -402,11 +402,17 @@ escape(Value, _Context) ->
 trace_compile(_Module, Filename, Options, _Context) ->
     case proplists:get_value(trace_position, Options) of
         {File, Line, _Col} ->
-            ?LOG_DEBUG("[template_compiler] Compiling \"~s\" (called from \"~s:~p\")",
-                        [Filename, File, Line]);
+            ?LOG_DEBUG(#{
+                text => <<"Compiling template">>,
+                filename => Filename,
+                at => File,
+                line => Line
+            });
         undefined ->
-            ?LOG_DEBUG("[template_compiler] Compiling \"~s\"",
-                        [Filename])
+            ?LOG_DEBUG(#{
+                text => <<"Compiling template">>,
+                filename => Filename
+            })
     end,
     ok.
 
@@ -416,11 +422,17 @@ trace_compile(_Module, Filename, Options, _Context) ->
 trace_render(Filename, Options, _Context) ->
     case proplists:get_value(trace_position, Options) of
         {File, Line, _Col} ->
-            ?LOG_DEBUG("[template_compiler] Include by \"~s:~p\" of \"~s\"",
-                        [File, Line, Filename]);
+            ?LOG_DEBUG(#{
+                text => <<"Template include">>,
+                filename => Filename,
+                at => File,
+                line => Line
+            });
         undefined ->
-            ?LOG_DEBUG("[template_compiler] Render \"~s\"",
-                        [Filename])
+            ?LOG_DEBUG(#{
+                text => <<"Template render">>,
+                filename => Filename
+            })
     end,
     ok.
 

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -237,20 +237,8 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
             <<>>;
         {error, enoent} ->
             <<>>;
-        {error, Reason} when is_list(Reason); is_binary(Reason) ->
-            R1 = try
-                iolist_to_binary(Reason)
-            catch _:_ ->
-                Reason
-            end,
-            ?LOG_ERROR(#{
-                text => <<"Template render error">>,
-                template => Template,
-                result => error,
-                reason => R1,
-                at => SrcFile,
-                line => SrcLine
-            }),
+        {error, Err} when is_map(Err) ->
+            ?LOG_ERROR(Err),
             <<>>;
         {error, Reason} ->
             ?LOG_ERROR(#{

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -237,7 +237,7 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
             ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => R1 }),
             <<>>;
         {error, Reason} ->
-            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => Reason}),
+            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => Reason }),
             <<>>
     end.
 

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -234,7 +234,7 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
             catch _:_ ->
                 Reason
             end,
-            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => R1}),
+            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => R1 }),
             <<>>;
         {error, Reason} ->
             ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => Reason}),

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -224,7 +224,7 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
         {ok, Result} ->
             Result;
         {error, enoent} when Method =:= normal ->
-            ?LOG_ERROR(#{ text => "Missing included template.", template => Template}),
+            ?LOG_ERROR(#{ text => "Missing included template.", template => Template }),
             <<>>;
         {error, enoent} ->
             <<>>;

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -224,7 +224,7 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
         {ok, Result} ->
             Result;
         {error, enoent} when Method =:= normal ->
-            ?LOG_ERROR("Missing included template ~p", [Template]),
+            ?LOG_ERROR(#{ text => "Missing included template.", template => Template}),
             <<>>;
         {error, enoent} ->
             <<>>;
@@ -234,10 +234,10 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
             catch _:_ ->
                 Reason
             end,
-            ?LOG_ERROR("Template render error: '~s' for template ~p", [R1, Template]),
+            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => R1}),
             <<>>;
         {error, Reason} ->
-            ?LOG_ERROR("Template render error: ~p for template ~p", [Reason, Template]),
+            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => Reason}),
             <<>>
     end.
 

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -215,6 +215,7 @@ include_1(SrcPos, all, Template, Runtime, ContextVars, Vars1, Context) ->
             end,
             Templates);
 include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
+    {SrcFile, SrcLine, _SrcCol} = SrcPos,
     Options = [
         {runtime, Runtime},
         {trace_position, SrcPos},
@@ -224,7 +225,15 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
         {ok, Result} ->
             Result;
         {error, enoent} when Method =:= normal ->
-            ?LOG_ERROR(#{ text => "Missing included template.", template => Template }),
+            ?LOG_ERROR(#{
+                text => <<"Included template not found">>,
+                template => Template,
+                srcpos => SrcPos,
+                result => error,
+                reason => enoent,
+                at => SrcFile,
+                line => SrcLine
+            }),
             <<>>;
         {error, enoent} ->
             <<>>;
@@ -234,10 +243,25 @@ include_1(SrcPos, Method, Template, Runtime, ContextVars, Vars1, Context) ->
             catch _:_ ->
                 Reason
             end,
-            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => R1 }),
+            ?LOG_ERROR(#{
+                text => <<"Template render error">>,
+                template => Template,
+                result => error,
+                reason => R1,
+                at => SrcFile,
+                line => SrcLine
+            }),
             <<>>;
         {error, Reason} ->
-            ?LOG_ERROR(#{ text => "Template render error.", template => Template, reason => Reason }),
+            ?LOG_ERROR(#{
+                text => <<"Template render error">>,
+                template => Template,
+                srcpos => SrcPos,
+                result => error,
+                reason => Reason,
+                at => SrcFile,
+                line => SrcLine
+            }),
             <<>>
     end.
 


### PR DESCRIPTION
This PR changes log messages to structured logging format.

- [x] Transform things to structured logging calls
- [x] Transform yecc errors to maps to improve readability. (See: https://www.erlang.org/doc/man/yecc.html)