### PR TITLE
Replace erlang_localtime with qdate_localtime

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,8 @@
 ]}.
 
 {deps, [
-    {erlang_localtime, "1.0.0"},
-    {zotonic_stdlib, "1.6.0"}
+    {qdate_localtime, "~> 1.2"},
+    {zotonic_stdlib, "~> 1.6"}
 ]}.
 
 {xref_checks, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,22 +1,22 @@
 {"1.2.0",
 [{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.11.0">>},1},
- {<<"erlang_localtime">>,{pkg,<<"erlang_localtime">>,<<"1.0.0">>},0},
+ {<<"qdate_localtime">>,{pkg,<<"qdate_localtime">>,<<"1.2.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},2},
  {<<"tls_certificate_check">>,
-  {pkg,<<"tls_certificate_check">>,<<"1.11.0">>},
+  {pkg,<<"tls_certificate_check">>,<<"1.16.0">>},
   1},
- {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.6.0">>},0}]}.
+ {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.11.2">>},0}]}.
 [
 {pkg_hash,[
  {<<"cowlib">>, <<"0B9FF9C346629256C42EBE1EEB769A83C6CB771A6EE5960BD110AB0B9B872063">>},
- {<<"erlang_localtime">>, <<"497DFD4D13523D3E0EECDCB8D6D59857CF642A17A6BDC6133FF906FDAF2AEF21">>},
+ {<<"qdate_localtime">>, <<"644ADE4C7F7EAC765E2048DFA714D78EA86BAF5255FE46279B2EAC5729760A07">>},
  {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
- {<<"tls_certificate_check">>, <<"609DCD503F31170F0799DAC380EB0E086388CF918FC769AAA60DDD6BBF575218">>},
- {<<"zotonic_stdlib">>, <<"872E85BD2DC8A49A4DA255E4DF6C1B4DDC993E59024D02303BD6A5DF0868859B">>}]},
+ {<<"tls_certificate_check">>, <<"45B05E3B993DBACE2E4EBCCB666EADBD038F1DA8F4DB9691F4F34A274DFB0BD7">>},
+ {<<"zotonic_stdlib">>, <<"CAC0BA50B041C38DD7925B990DAC084616CCA1E042FE82E458A94E52A89F3E26">>}]},
 {pkg_hash_ext,[
  {<<"cowlib">>, <<"2B3E9DA0B21C4565751A6D4901C20D1B4CC25CBB7FD50D91D2AB6DD287BC86A9">>},
- {<<"erlang_localtime">>, <<"46E3F7B18477B377EC71F9DCD91C4D30FE82A128FFA9F89BE1595D4D08414844">>},
+ {<<"qdate_localtime">>, <<"98A538A5B6046B8652DFC5630B030D0414A1B31D0130C81FA6B88B5C1E625109">>},
  {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
- {<<"tls_certificate_check">>, <<"4AB962212EF7C87482619CB298E1FE06E047B57F0BD58CC417B3B299EB8D036E">>},
- {<<"zotonic_stdlib">>, <<"9139167866615F226C3915B6082B317892E276F3A9C78C5A99CD497FA589444E">>}]}
+ {<<"tls_certificate_check">>, <<"3DC0508C749619B8D6A5E21ACA4D719C184F065541795B0556398C8E574A3064">>},
+ {<<"zotonic_stdlib">>, <<"AEBF9DD330207A9FB73FC1744EE4037BAC4B62A21EB13D6DA5BD951A5D658C89">>}]}
 ].


### PR DESCRIPTION
In Zotonic we use qdate_localtime, which is better maintained than erlang_localtime.

They both contain the same modules, so we need to fix only a single app.

Also upgrade zotonic_stdlib and tls_certificate_check
