### PR TITLE
Reduce atom leak

### DIFF
--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -346,7 +346,7 @@ module_name(Runtime, Filename, SpecialContextArgs, Tokens) ->
     },
     TokenChecksum = crypto:hash(sha, term_to_binary(Term)),
     Hex = z_string:to_lower(z_url:hex_encode(TokenChecksum)),
-    binary_to_atom(iolist_to_binary(["tpl_",Hex]), 'utf8').
+    template_compiler_utils:to_atom(iolist_to_binary(["tpl_",Hex])).
 
 % Ensure that duplicate files have the same checksum by removing the filename.
 remove_srcpos(Tokens) ->

--- a/src/template_compiler_expr.erl
+++ b/src/template_compiler_expr.erl
@@ -7,9 +7,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -186,7 +186,7 @@ compile({model, [{identifier, SrcPos, Model} | Path ], OptPayload}, #cs{runtime=
             "  {error, _} -> undefined "
             "end",
             [
-                {model, erl_syntax:atom(binary_to_atom(Model, 'utf8'))},
+                {model, erl_syntax:atom(template_compiler_utils:to_atom(Model))},
                 {path, erl_syntax:list(PathAsts)},
                 {payload, PayloadAst},
                 {v1, erl_syntax:variable(V1)},
@@ -219,7 +219,7 @@ find_value_lookup([
     Ws1 = Ws#ws{is_forloop_var=true},
     ValueLookupAsts = [
         erl_syntax:atom(forloop),
-        erl_syntax:atom(binary_to_atom(Key, utf8))
+        erl_syntax:atom(template_compiler_utils:to_atom(Key))
     ],
     Ast = merl:qquote(
             erl_syntax:get_pos(SrcPos),

--- a/src/template_compiler_scanner.erl
+++ b/src/template_compiler_scanner.erl
@@ -3,9 +3,9 @@
 %%% @author    Evan Miller <emmiller@gmail.com>
 %%% @author    Marc Worrell <marc@worrell.nl>
 %%% @copyright 2008 Roberto Saccon, Evan Miller; 2009-2020 Marc Worrell
-%%% @doc 
+%%% @doc
 %%% Template language scanner
-%%% @end  
+%%% @end
 %%%
 %%% The MIT License
 %%%
@@ -43,7 +43,7 @@
 -author('emmiller@gmail.com').
 -author('marc@worrell.nl').
 
--export([scan/1, scan/2]). 
+-export([scan/1, scan/2]).
 
 
 %%====================================================================
@@ -66,11 +66,11 @@ scan(SourceRef, Template) when is_binary(Template) ->
     scan(Template, [], {SourceRef, 1, 1}, in_text).
 
 
-identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc}) 
-  when PrevToken =:= open_tag; 
+identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc})
+  when PrevToken =:= open_tag;
        PrevToken =:= all_keyword;
        PrevToken =:= optional_keyword ->
-    %% the last two guards really ought to be for it's own fun, 
+    %% the last two guards really ought to be for it's own fun,
     %% since they only apply for [cat]include (the last one only for include)
 
     %% At the start of a {% .... %} tag we accept all keywords
@@ -91,12 +91,12 @@ identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc})
         <<"m">>
     ],
     Type = case lists:member(String, Keywords) of
-        true -> 
-            case list_to_atom(binary_to_list(String) ++ "_keyword") of
+        true ->
+            case template_compiler_utils:to_atom(binary_to_list(String) ++ "_keyword") of
                 elseif_keyword -> elif_keyword;
                 KWA -> KWA
             end;
-        _ -> 
+        _ ->
             identifier
     end,
     {Type, [{Type, Pos, String}|Acc]};
@@ -115,9 +115,9 @@ identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc}) when PrevToke
     Keywords = [
         <<"in">>, <<"not">>, <<"or">>, <<"and">>, <<"xor">>, <<"firstof">>,
         <<"regroup">>, <<"templatetag">>, <<"with">>, <<"as">>
-    ], 
+    ],
     Type = case lists:member(String, Keywords) of
-        true -> list_to_atom(binary_to_list(String) ++ "_keyword");
+        true -> template_compiler_utils:to_atom(binary_to_list(String) ++ "_keyword");
         _ ->    identifier
     end,
     {Type, [{Type, Pos, String}|Acc]};
@@ -128,15 +128,15 @@ identifier_to_keyword({identifier, Pos, String}, {_PrevToken, Acc}) ->
         <<"in">>, <<"not">>, <<"or">>, <<"and">>, <<"xor">>, <<"firstof">>,
         <<"regroup">>, <<"templatetag">>, <<"with">>, <<"as">>,
         <<"m">>
-    ], 
+    ],
     Type = case lists:member(String, Keywords) of
-        true -> list_to_atom(binary_to_list(String) ++ "_keyword");
+        true -> template_compiler_utils:to_atom(binary_to_list(String) ++ "_keyword");
         _ ->    identifier
     end,
     {Type, [{Type, Pos, String}|Acc]};
 identifier_to_keyword({Type, Pos, String}, {_PrevToken, Acc}) ->
     {Type, [{Type, Pos, String}|Acc]}.
-    
+
 
 scan(<<>>, Scanned, _, in_text) ->
     {_Token, ScannedKeyword} = lists:foldr(fun identifier_to_keyword/2, {'$eof', []}, Scanned),
@@ -198,13 +198,13 @@ scan(<<"{{", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
 scan(<<"<!--{_", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
     scan(T, [
             {trans_text, {SourceRef, Row, Column + 6}, <<"">>},
-            {open_trans, {SourceRef, Row, Column}, <<"<!--{_">>} | Scanned], 
+            {open_trans, {SourceRef, Row, Column}, <<"<!--{_">>} | Scanned],
     {SourceRef, Row, Column + 6}, {in_trans, <<"_}-->">>});
 
 scan(<<"{_", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
     scan(T, [
             {trans_text, {SourceRef, Row, Column + 2}, <<>>},
-            {open_trans, {SourceRef, Row, Column}, <<"{_">>} | Scanned], 
+            {open_trans, {SourceRef, Row, Column}, <<"{_">>} | Scanned],
         {SourceRef, Row, Column + 2}, {in_trans, <<"_}">>});
 
 scan(<<"_}-->", T/binary>>, Scanned, {SourceRef, Row, Column}, {in_trans, <<"_}-->">>}) ->
@@ -235,11 +235,11 @@ scan(<<_/utf8, T/binary>>, Scanned, {SourceRef, Row, Column}, {in_comment, Close
     scan(T, Scanned, {SourceRef, Row, Column + 1}, {in_comment, Closer});
 
 scan(<<"<!--{%", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
-    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"<!--{%">>} | Scanned], 
+    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"<!--{%">>} | Scanned],
         {SourceRef, Row, Column + 6}, {in_code, <<"%}-->">>});
 
 scan(<<"{%", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
-    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"{%">>} | Scanned], 
+    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"{%">>} | Scanned],
         {SourceRef, Row, Column + 2}, {in_code, <<"%}">>});
 
 scan(<<H/utf8, T/binary>>, Scanned, {SourceRef, Row, Column}, {in_trans, Closer}) ->

--- a/src/template_compiler_utils.erl
+++ b/src/template_compiler_utils.erl
@@ -7,9 +7,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,8 +56,14 @@ next_context_var(CState, #ws{nr=Nr} = Ws) ->
 
 %% @doc Convert a list or binary to an atom.
 -spec to_atom(string()|binary()|atom()) -> atom().
-to_atom(L) when is_list(L) -> erlang:list_to_atom(L);
-to_atom(B) when is_binary(B) -> erlang:binary_to_atom(B, 'utf8');
+to_atom(L) when is_list(L) -> case catch erlang:list_to_existing_atom(L) of
+                                  A when is_atom(A) -> A;
+                                  _ -> erlang:list_to_atom(L)
+                              end;
+to_atom(B) when is_binary(B) -> case catch erlang:binary_to_existing_atom(B, 'utf8') of
+                                    A when is_atom(A) -> A;
+                                    _ -> erlang:binary_to_atom(B, 'utf8')
+                                end;
 to_atom(A) when is_atom(A) -> A.
 
 


### PR DESCRIPTION
I've noticed that convert `to_atom` is used often.
This PR can help to reduce the atom leak by first trying to convert to an existing atom.