### PR TITLE
Cleanup and small fixes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,7 +40,7 @@ test: $(REBAR)
 	$(REBAR) $(REBAR_OPTS) ct
 
 edoc: $(REBAR)
-	$(REBAR) ex_doc
+	ELIXIR_ERL_OPTIONS="+fnu" $(REBAR) ex_doc
 
 # Cleaning
 .PHONY: clean_logs

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ extends() -> undefined.
 
 %% The templates that this template includes.
 %% Includes which use variable names for the template name are not listed.
-includes() -> [ 
+includes() -> [
         #{
             template => <<"foo.tpl">>,
             line => 5,
@@ -515,7 +515,7 @@ escaped and surrounded with `<pre>...</pre>`.
 
 Whitespace Handling
 -------------------
- 
+
 - A single trailing newline is stripped, from the template, if present.
 - Other whitespace, like tabs, newlines and spaces are returned unchanged.
 

--- a/include/template_compiler.hrl
+++ b/include/template_compiler.hrl
@@ -7,9 +7,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/filter_template_compiler_test.erl
+++ b/src/filter_template_compiler_test.erl
@@ -9,9 +9,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/filter_template_compiler_test_set.erl
+++ b/src/filter_template_compiler_test_set.erl
@@ -9,9 +9,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -142,7 +142,7 @@ handle_call({compile_request, TplKey, Filename}, From, State) ->
         false ->
             FTpl = {Filename, TplKey},
             State1 = case lists:member(FTpl, State#state.filename_keys) of
-                        false -> 
+                        false ->
                             State#state{
                                 filename_keys=[ FTpl | State#state.filename_keys ]
                             };
@@ -210,7 +210,7 @@ handle_cast({flush_context_name, ContextName}, State) ->
             end,
             Matched),
     FilenameKeys = lists:filter(
-                        fun({_Fn, K}) -> 
+                        fun({_Fn, K}) ->
                             K =/= ContextName
                         end,
                         State#state.filename_keys),
@@ -271,4 +271,3 @@ split_waiters(TplKey, State) ->
                                 end,
                                 State#state.waiting),
     {Ready, State#state{waiting=Waiting}}.
-

--- a/src/template_compiler_admin.erl
+++ b/src/template_compiler_admin.erl
@@ -40,8 +40,6 @@
     ]).
 
 -include_lib("kernel/include/logger.hrl").
--include("template_compiler.hrl").
--include("template_compiler_internal.hrl").
 
 -type gen_server_from() :: {pid(),term()}.
 

--- a/src/template_compiler_app.erl
+++ b/src/template_compiler_app.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/template_compiler_element.erl
+++ b/src/template_compiler_element.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -150,8 +150,8 @@ compile({block, {identifier, SrcPos, Name}, _Elts}, CState, Ws) ->
                 erl_syntax:atom(CState#cs.runtime),
                 erl_syntax:variable(CState#cs.context_var)
             ]),
-    {value, {BlockName, _Tree, BlockWs}} = lists:keysearch(BlockName, 1, CState#cs.blocks), 
-    Ws1 = Ws#ws{is_forloop_var = Ws#ws.is_forloop_var or BlockWs#ws.is_forloop_var}, 
+    {value, {BlockName, _Tree, BlockWs}} = lists:keysearch(BlockName, 1, CState#cs.blocks),
+    Ws1 = Ws#ws{is_forloop_var = Ws#ws.is_forloop_var or BlockWs#ws.is_forloop_var},
     {Ws1, template_compiler_utils:set_pos(SrcPos, Ast)};
 compile({inherit, {_, _SrcPos, _}}, #cs{block=undefined}, Ws) ->
     {Ws, erl_syntax:abstract(<<>>)};

--- a/src/template_compiler_expr.erl
+++ b/src/template_compiler_expr.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/template_compiler_internal.hrl
+++ b/src/template_compiler_internal.hrl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,4 +62,3 @@
         context_vars = [] :: list(binary()),
         is_autoescape = false :: boolean()
     }).
-

--- a/src/template_compiler_module.erl
+++ b/src/template_compiler_module.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/template_compiler_module.erl
+++ b/src/template_compiler_module.erl
@@ -25,8 +25,6 @@
     ]).
 
 -include_lib("syntax_tools/include/merl.hrl").
--include("template_compiler.hrl").
--include("template_compiler_internal.hrl").
 
 compile(Module, Filename, Mtime, IsAutoid, Runtime, Extends, Includes, BlockAsts, undefined) ->
     compile(Module, Filename, Mtime, IsAutoid, Runtime, Extends, Includes, BlockAsts, erl_syntax:abstract(<<>>));

--- a/src/template_compiler_operators.erl
+++ b/src/template_compiler_operators.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -216,31 +216,31 @@ to_values({trans, _} = Tr, B, Runtime, Context) ->
     to_values(Runtime:to_simple_value(Tr, Context), B, Runtime, Context);
 to_values(A, {trans, _} = Tr, Runtime, Context) ->
     to_values(A, Runtime:to_simple_value(Tr, Context), Runtime, Context);
-to_values(A, B, _Runtime, _Context) when is_number(A), is_number(B) -> 
+to_values(A, B, _Runtime, _Context) when is_number(A), is_number(B) ->
     {A,B};
-to_values(A, B, Runtime, Context) when is_boolean(A); is_boolean(B) -> 
-    {z_convert:to_bool(Runtime:to_simple_value(A, Context)), 
+to_values(A, B, Runtime, Context) when is_boolean(A); is_boolean(B) ->
+    {z_convert:to_bool(Runtime:to_simple_value(A, Context)),
      z_convert:to_bool(Runtime:to_simple_value(B, Context))};
-to_values(A, B, Runtime, Context) when is_integer(A); is_integer(B) -> 
+to_values(A, B, Runtime, Context) when is_integer(A); is_integer(B) ->
     {to_maybe_integer(A, Runtime, Context),
      to_maybe_integer(B, Runtime, Context)};
-to_values(A, B, Runtime, Context) when is_float(A); is_float(B) -> 
+to_values(A, B, Runtime, Context) when is_float(A); is_float(B) ->
     {to_maybe_float(A, Runtime, Context),
      to_maybe_float(B, Runtime, Context)};
-to_values(A, B, _Runtime, _Context) when is_binary(A), is_binary(B) -> 
+to_values(A, B, _Runtime, _Context) when is_binary(A), is_binary(B) ->
     {A,B};
-to_values(A, B, _Runtime, _Context) when is_list(A), is_list(B) -> 
+to_values(A, B, _Runtime, _Context) when is_list(A), is_list(B) ->
     {A,B};
-to_values(A, B, Runtime, Context) when is_binary(A); is_binary(B) -> 
+to_values(A, B, Runtime, Context) when is_binary(A); is_binary(B) ->
     {to_maybe_binary(A, Runtime, Context),
      to_maybe_binary(B, Runtime, Context)};
-to_values(A, B, Runtime, Context) when is_tuple(A), is_tuple(B) -> 
-    {Runtime:to_simple_value(A, Context), 
+to_values(A, B, Runtime, Context) when is_tuple(A), is_tuple(B) ->
+    {Runtime:to_simple_value(A, Context),
      Runtime:to_simple_value(B, Context)};
-to_values(A, B, Runtime, Context) when is_binary(A); is_binary(B) -> 
+to_values(A, B, Runtime, Context) when is_binary(A); is_binary(B) ->
     {to_maybe_binary(A, Runtime, Context),
      to_maybe_binary(B, Runtime, Context)};
-to_values(A, B, Runtime, Context) -> 
+to_values(A, B, Runtime, Context) ->
     {to_maybe_list(A, Runtime, Context),
      to_maybe_list(B, Runtime, Context)}.
 
@@ -250,11 +250,11 @@ to_numbers(undefined, B, _Runtime, _Context) ->
     {undefined, B};
 to_numbers(A, undefined, _Runtime, _Context) ->
     {A, undefined};
-to_numbers(A, B, _Runtime, _Context) when is_number(A), is_number(B) -> 
+to_numbers(A, B, _Runtime, _Context) when is_number(A), is_number(B) ->
     {A,B};
-to_numbers(A, B, Runtime, Context) when is_float(A); is_float(B) -> 
+to_numbers(A, B, Runtime, Context) when is_float(A); is_float(B) ->
     {to_maybe_float(A, Runtime, Context), to_maybe_float(B, Runtime, Context)};
-to_numbers(A, B, Runtime, Context) -> 
+to_numbers(A, B, Runtime, Context) ->
     {to_maybe_integer(A, Runtime, Context), to_maybe_integer(B, Runtime, Context)}.
 
 to_maybe_integer(A, _Runtime, _Context) when is_number(A) ->

--- a/src/template_compiler_operators.erl
+++ b/src/template_compiler_operators.erl
@@ -129,6 +129,7 @@ divide(A, B, Runtime, Context) ->
         {_, undefined} -> undefined;
         {_, 0} -> undefined;
         {_, +0.0} -> undefined;
+        {_, -0.0} -> undefined;
         {A1, B1} -> A1 / B1
     end.
 
@@ -145,6 +146,7 @@ modulo(A, B, Runtime, Context) ->
         {_, undefined} -> undefined;
         {_, 0} -> undefined;
         {_, +0.0} -> undefined;
+        {_, -0.0} -> undefined;
         {A1, B1} -> A1 rem B1
     end.
 

--- a/src/template_compiler_operators.erl
+++ b/src/template_compiler_operators.erl
@@ -128,7 +128,7 @@ divide(A, B, Runtime, Context) ->
         {undefined, _} -> undefined;
         {_, undefined} -> undefined;
         {_, 0} -> undefined;
-        {_, 0.0} -> undefined;
+        {_, +0.0} -> undefined;
         {A1, B1} -> A1 / B1
     end.
 
@@ -144,7 +144,7 @@ modulo(A, B, Runtime, Context) ->
         {undefined, _} -> undefined;
         {_, undefined} -> undefined;
         {_, 0} -> undefined;
-        {_, 0.0} -> undefined;
+        {_, +0.0} -> undefined;
         {A1, B1} -> A1 rem B1
     end.
 

--- a/src/template_compiler_parser.yrl
+++ b/src/template_compiler_parser.yrl
@@ -6,7 +6,7 @@
 %%% @copyright 2009-2016 Marc Worrell
 %%% @doc Template language grammar
 %%% @changes Marc Worrell - added print/image/scomp, more args options etc.
-%%% @end  
+%%% @end
 %%%
 %%% The MIT License
 %%%
@@ -50,7 +50,7 @@ Nonterminals
     ExtendsTag
     OverrulesTag
     InheritTag
-    
+
     IncludeTag
     CatIncludeTag
     NowTag
@@ -71,7 +71,7 @@ Nonterminals
     FilterBraced
     EndFilterBraced
     Filters
-    
+
     ScriptBlock
     ScriptBraced
     EndScriptBraced
@@ -94,12 +94,12 @@ Nonterminals
     IfEqualBlock
     IfEqualBraced
     IfEqualExpression
-    EndIfEqualBraced  
-    
+    EndIfEqualBraced
+
     IfNotEqualBlock
     IfNotEqualBraced
     IfNotEqualExpression
-    EndIfNotEqualBraced      
+    EndIfNotEqualBraced
 
     AutoEscapeBlock
     AutoEscapeBraced
@@ -108,7 +108,7 @@ Nonterminals
     WithBlock
     WithBraced
     EndWithBraced
-    
+
     Value
     TermValue
     Variable
@@ -118,14 +118,14 @@ Nonterminals
 
     ModelCall
     OptModelArg
-    
+
     LibTag
     LibUrlTag
     LibList
-    
+
     LoadTag
     LoadNames
-    
+
     CustomTag
     WithArgs
     Args

--- a/src/template_compiler_runtime.erl
+++ b/src/template_compiler_runtime.erl
@@ -9,9 +9,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -105,13 +105,13 @@ map_template(Template, _Vars, _Context) ->
                     Error;
                 PrivDir ->
                     {ok, #template_file{
-                        template=Template, 
+                        template=Template,
                         filename=filename:join([PrivDir, SubDir, Template])
                     }}
             end;
         {ok, Dir} when is_list(Dir); is_binary(Dir) ->
             {ok, #template_file{
-                template=Template, 
+                template=Template,
                 filename=filename:join([Dir, Template])
             }};
         undefined ->
@@ -282,7 +282,7 @@ lookup_translation({trans, Tr}, TplVars, _Context) when is_map(TplVars) ->
     case lists:keyfind(Lang, 1, Tr) of
         {Lang, Text} ->
             Text;
-        false when Lang =/= en -> 
+        false when Lang =/= en ->
             case lists:keyfind(en, 1, Tr) of
                 {Lang, Text} -> Text;
                 false -> <<>>
@@ -304,7 +304,7 @@ custom_tag(Tag, Args, Vars, Context) ->
 
 %% @doc Render image/image_url/image_data_url/media/url/lib/lib_url tag.
 %%      The Expr is the media item or dispatch rule.
--spec builtin_tag(template_compiler:builtin_tag(), Expr::term(), Args::list(), Vars::map(), Context::term()) -> 
+-spec builtin_tag(template_compiler:builtin_tag(), Expr::term(), Args::list(), Vars::map(), Context::term()) ->
             template_compiler:render_result().
 builtin_tag(_Tag, _Expr, _Args, _Vars, _Context) ->
     <<>>.
@@ -365,13 +365,13 @@ to_simple_value(T, _Context) -> T.
 %% @doc Convert a value to an render_result, used for converting values in {{ ... }} expressions.
 -spec to_render_result(Value::term(), TplVars::map(), Context::term()) -> template_compiler:render_result().
 to_render_result(undefined, _TplVars, _Context) -> <<>>;
-to_render_result(B, _TplVars, _Context) when is_binary(B) -> 
+to_render_result(B, _TplVars, _Context) when is_binary(B) ->
     B;
-to_render_result(A, _TplVars, _Context) when is_atom(A) -> 
+to_render_result(A, _TplVars, _Context) when is_atom(A) ->
     atom_to_binary(A, 'utf8');
-to_render_result(N, _TplVars, _Context) when is_integer(N) -> 
+to_render_result(N, _TplVars, _Context) when is_integer(N) ->
     integer_to_binary(N);
-to_render_result(F, _TplVars, _Context) when is_float(F) -> 
+to_render_result(F, _TplVars, _Context) when is_float(F) ->
     io_lib:format("~p", [F]);
 to_render_result({{Y,M,D},{H,I,S}} = Date, TplVars, _Context)
     when is_integer(Y), is_integer(M), is_integer(D),
@@ -380,7 +380,7 @@ to_render_result({{Y,M,D},{H,I,S}} = Date, TplVars, _Context)
         {tz, maps:get(tz, TplVars, "GMT")}
     ],
     z_dateformat:format(Date, "Y-m-d H:i:s", Options);
-to_render_result(T, _TplVars, _Context) when is_tuple(T) -> 
+to_render_result(T, _TplVars, _Context) when is_tuple(T) ->
     io_lib:format("~p", [T]);
 to_render_result(L, TplVars, Context) when is_list(L) ->
     try
@@ -441,4 +441,3 @@ trace_render(Filename, Options, _Context) ->
 -spec trace_block({binary(), integer(), integer()}, atom(), atom(), term()) -> ok | {ok, iodata(), iodata()}.
 trace_block(_SrcPos, _Name, _Module, _Context) ->
     ok.
-

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -89,7 +89,7 @@ forloop_fold(List, Idents, Fun, Runtime, IsContextVars, Vars, Context) ->
 
 % For loop without any forloop variable, use a direct map
 forloop_map(List, Idents, Fun, Runtime, true, Vars, Context) ->
-    [ 
+    [
         begin
             Vars1 = assign_vars(Idents, Val, Vars),
             Fun(Vars1, Runtime:set_context_vars(Vars1, Context))
@@ -184,8 +184,8 @@ block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
 
 
 %% @doc Include a template.
--spec include({File::binary(), Line::integer(), Col::integer()}, normal|optional|all, 
-        template_compiler:template(), list({atom(),term()}), atom(), list(binary()), boolean(), map(), term()) -> 
+-spec include({File::binary(), Line::integer(), Col::integer()}, normal|optional|all,
+        template_compiler:template(), list({atom(),term()}), atom(), list(binary()), boolean(), map(), term()) ->
         template_compiler:render_result().
 include(SrcPos, Method, Template, Args, Runtime, ContextVars, IsContextVars, Vars, Context) ->
     Vars1 = lists:foldl(
@@ -275,7 +275,7 @@ print(Expr) ->
     ].
 
 
-%% @doc Make an unique string (about 11 characters). Used for expanding unique args in templates. The string only 
+%% @doc Make an unique string (about 11 characters). Used for expanding unique args in templates. The string only
 %%      consists of the characters A-Z and 0-9 and is safe to use as HTML element id.
 -spec unique() -> binary().
 unique() ->

--- a/src/template_compiler_scanner.erl
+++ b/src/template_compiler_scanner.erl
@@ -543,4 +543,3 @@ find_endraw_close(<<"%}", Rest/binary>>, <<"%}">>, Row, Column) ->
     {ok, Rest, Row, Column+2};
 find_endraw_close(_T, _Closer, _Row, _Colum) ->
     notfound.
-

--- a/src/template_compiler_scanner.erl
+++ b/src/template_compiler_scanner.erl
@@ -3,9 +3,9 @@
 %%% @author    Evan Miller <emmiller@gmail.com>
 %%% @author    Marc Worrell <marc@worrell.nl>
 %%% @copyright 2008 Roberto Saccon, Evan Miller; 2009-2020 Marc Worrell
-%%% @doc 
+%%% @doc
 %%% Template language scanner
-%%% @end  
+%%% @end
 %%%
 %%% The MIT License
 %%%
@@ -43,7 +43,12 @@
 -author('emmiller@gmail.com').
 -author('marc@worrell.nl').
 
--export([scan/1, scan/2]). 
+-export([scan/1, scan/2]).
+
+-export_type([template/0, tokens/0]).
+
+-type template():: string() | binary().
+-type tokens() :: [tuple()].
 
 -define(IS_EOF(S),
         (S =:= <<>> orelse S =:= <<"\n">> orelse S =:= <<"\r\n">>)).
@@ -51,14 +56,13 @@
 %%====================================================================
 %% API
 %%====================================================================
+
 %%--------------------------------------------------------------------
-%% @spec scan(T::template()) -> {ok, S::tokens()} | {error, Reason}
-%% @type template() = string() | binary(). Template to parse
-%% @type tokens() = [tuple()].
 %% @doc Scan the template string T and return the a token list or
 %% an error.
 %% @end
 %%--------------------------------------------------------------------
+-spec scan(template()) -> {ok, tokens()} | {error, binary()}.
 scan(Template) when is_binary(Template) ->
     scan(undefined, Template).
 
@@ -68,11 +72,11 @@ scan(SourceRef, Template) when is_binary(Template) ->
     scan(Template, [], {SourceRef, 1, 1}, in_text).
 
 
-identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc}) 
-  when PrevToken =:= open_tag; 
+identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc})
+  when PrevToken =:= open_tag;
        PrevToken =:= all_keyword;
        PrevToken =:= optional_keyword ->
-    %% the last two guards really ought to be for it's own fun, 
+    %% the last two guards really ought to be for it's own fun,
     %% since they only apply for [cat]include (the last one only for include)
 
     %% At the start of a {% .... %} tag we accept all keywords
@@ -93,12 +97,12 @@ identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc})
         <<"m">>
     ],
     Type = case lists:member(String, Keywords) of
-        true -> 
+        true ->
             case list_to_atom(binary_to_list(String) ++ "_keyword") of
                 elseif_keyword -> elif_keyword;
                 KWA -> KWA
             end;
-        _ -> 
+        _ ->
             identifier
     end,
     {Type, [{Type, Pos, String}|Acc]};
@@ -117,7 +121,7 @@ identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc}) when PrevToke
     Keywords = [
         <<"in">>, <<"not">>, <<"or">>, <<"and">>, <<"xor">>, <<"firstof">>,
         <<"regroup">>, <<"templatetag">>, <<"with">>, <<"as">>
-    ], 
+    ],
     Type = case lists:member(String, Keywords) of
         true -> list_to_atom(binary_to_list(String) ++ "_keyword");
         _ ->    identifier
@@ -130,7 +134,7 @@ identifier_to_keyword({identifier, Pos, String}, {_PrevToken, Acc}) ->
         <<"in">>, <<"not">>, <<"or">>, <<"and">>, <<"xor">>, <<"firstof">>,
         <<"regroup">>, <<"templatetag">>, <<"with">>, <<"as">>,
         <<"m">>
-    ], 
+    ],
     Type = case lists:member(String, Keywords) of
         true -> list_to_atom(binary_to_list(String) ++ "_keyword");
         _ ->    identifier
@@ -138,7 +142,7 @@ identifier_to_keyword({identifier, Pos, String}, {_PrevToken, Acc}) ->
     {Type, [{Type, Pos, String}|Acc]};
 identifier_to_keyword({Type, Pos, String}, {_PrevToken, Acc}) ->
     {Type, [{Type, Pos, String}|Acc]}.
-    
+
 
 scan(Eof, Scanned, _, in_text) when ?IS_EOF(Eof) ->
     {_Token, ScannedKeyword} = lists:foldr(fun identifier_to_keyword/2, {'$eof', []}, Scanned),
@@ -200,13 +204,13 @@ scan(<<"{{", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
 scan(<<"<!--{_", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
     scan(T, [
             {trans_text, {SourceRef, Row, Column + 6}, <<"">>},
-            {open_trans, {SourceRef, Row, Column}, <<"<!--{_">>} | Scanned], 
+            {open_trans, {SourceRef, Row, Column}, <<"<!--{_">>} | Scanned],
     {SourceRef, Row, Column + 6}, {in_trans, <<"_}-->">>});
 
 scan(<<"{_", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
     scan(T, [
             {trans_text, {SourceRef, Row, Column + 2}, <<>>},
-            {open_trans, {SourceRef, Row, Column}, <<"{_">>} | Scanned], 
+            {open_trans, {SourceRef, Row, Column}, <<"{_">>} | Scanned],
         {SourceRef, Row, Column + 2}, {in_trans, <<"_}">>});
 
 scan(<<"_}-->", T/binary>>, Scanned, {SourceRef, Row, Column}, {in_trans, <<"_}-->">>}) ->
@@ -237,11 +241,11 @@ scan(<<_/utf8, T/binary>>, Scanned, {SourceRef, Row, Column}, {in_comment, Close
     scan(T, Scanned, {SourceRef, Row, Column + 1}, {in_comment, Closer});
 
 scan(<<"<!--{%", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
-    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"<!--{%">>} | Scanned], 
+    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"<!--{%">>} | Scanned],
         {SourceRef, Row, Column + 6}, {in_code, <<"%}-->">>});
 
 scan(<<"{%", T/binary>>, Scanned, {SourceRef, Row, Column}, in_text) ->
-    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"{%">>} | Scanned], 
+    scan(T, [{open_tag, {SourceRef, Row, Column}, <<"{%">>} | Scanned],
         {SourceRef, Row, Column + 2}, {in_code, <<"%}">>});
 
 scan(<<H/utf8, T/binary>>, Scanned, {SourceRef, Row, Column}, {in_trans, Closer}) ->

--- a/src/template_compiler_sup.erl
+++ b/src/template_compiler_sup.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/template_compiler_utils.erl
+++ b/src/template_compiler_utils.erl
@@ -8,9 +8,9 @@
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -97,5 +97,3 @@ set_pos(SrcPos, Tree) ->
 -spec pos({file:filename_all(), pos_integer(), pos_integer()}) -> {pos_integer(), pos_integer()}.
 pos({_File, Line, Column}) ->
     {Line, Column}.
-
-

--- a/src/template_compiler_utils.erl
+++ b/src/template_compiler_utils.erl
@@ -31,7 +31,6 @@
     set_pos/2
     ]).
 
--include("template_compiler.hrl").
 -include("template_compiler_internal.hrl").
 -include_lib("kernel/include/file.hrl").
 

--- a/test/template_compiler_basic_SUITE.erl
+++ b/test/template_compiler_basic_SUITE.erl
@@ -16,7 +16,7 @@ all() ->
     ].
 
 groups() ->
-    [{basic, [], 
+    [{basic, [],
         [hello_world_test
         ,hello_world2_test
         ,hello_world_block_test

--- a/test/template_compiler_expr_SUITE.erl
+++ b/test/template_compiler_expr_SUITE.erl
@@ -171,7 +171,6 @@ expr_andalso(_Config) ->
     1 = erlang:get(x),
     erlang:erase(x).
 
-
 test_data_dir(Config) ->
     filename:join([
         filename:dirname(filename:dirname(?config(data_dir, Config))),

--- a/test/template_compiler_tags_SUITE.erl
+++ b/test/template_compiler_tags_SUITE.erl
@@ -16,7 +16,7 @@ all() ->
     ].
 
 groups() ->
-    [{basic, [], 
+    [{basic, [],
         [print_test
         ,custom_tag_test
         ,filter_tag_test
@@ -89,4 +89,3 @@ test_data_dir(Config) ->
     filename:join([
         filename:dirname(filename:dirname(?config(data_dir, Config))),
         "test-data"]).
-


### PR DESCRIPTION
This PR:
- Removes trailing whitespaces and extra ending new lines;
- Removes non-used headers;
- Try to fix the `ex_doc` warning:
>===> warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell) or set the ELIXIR_ERL_OPTIONS="+fnu" environment variable
- Fix float warnings
>Warning: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
- Use `-type` and `-spec` attributes instead of defining them in docs.