### PR TITLE
Add compose tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,43 @@ Then `a.tpl` renders like:
 this is hello the base world template
 ```
 
+#### Template compose
+
+This includes a template, but also defines extra blocks for the template
+to overrule the blocks in the template.
+
+It is like a nameless `{% overrules %}` template, directly defined in the
+template text at the spot of the include.
+
+
+```django
+{% compose "a.tpl" what="moon" %}
+{% block a %}{{ what }}{% endblock %}
+{% endcompose %}
+```
+
+And a.tpl is like:
+
+```django
+Hello {% block a %}world{% endblock %}, and bye.
+```
+
+Then the above renders:
+
+```
+Hello moon, and bye.
+```
+
+There is also a `catcompose` to use a `catinclude`:
+
+```django
+{% catcompose "a.tpl" id what="moon" %}
+{% block a %}{{ what }}{% endblock %}
+{% endcompose %}
+
+```
+
+
 #### If tag
 
 Conditionally show or hide parts of a template:

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,20 +3,20 @@
  {<<"qdate_localtime">>,{pkg,<<"qdate_localtime">>,<<"1.2.0">>},0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.7">>},2},
  {<<"tls_certificate_check">>,
-  {pkg,<<"tls_certificate_check">>,<<"1.20.0">>},
+  {pkg,<<"tls_certificate_check">>,<<"1.21.0">>},
   1},
- {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.15.0">>},0}]}.
+ {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.20.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"cowlib">>, <<"A9FA9A625F1D2025FE6B462CB865881329B5CAFF8F1854D1CBC9F9533F00E1E1">>},
  {<<"qdate_localtime">>, <<"644ADE4C7F7EAC765E2048DFA714D78EA86BAF5255FE46279B2EAC5729760A07">>},
  {<<"ssl_verify_fun">>, <<"354C321CF377240C7B8716899E182CE4890C5938111A1296ADD3EC74CF1715DF">>},
- {<<"tls_certificate_check">>, <<"1AC0C53F95E201FEB8D398EF9D764AE74175231289D89F166BA88A7F50CD8E73">>},
- {<<"zotonic_stdlib">>, <<"0876BB82B9CFDE331DC758C8A7818181BB5654F137723DF137DE53C25AD3DD1D">>}]},
+ {<<"tls_certificate_check">>, <<"042AB2C0C860652BC5CF69C94E3A31F96676D14682E22EC7813BD173CEFF1788">>},
+ {<<"zotonic_stdlib">>, <<"51A484CF4B692042A5A251510010E00FF419CFF6C85E094DD3E00E283817B53D">>}]},
 {pkg_hash_ext,[
  {<<"cowlib">>, <<"163B73F6367A7341B33C794C4E88E7DBFE6498AC42DCD69EF44C5BC5507C8DB0">>},
  {<<"qdate_localtime">>, <<"98A538A5B6046B8652DFC5630B030D0414A1B31D0130C81FA6B88B5C1E625109">>},
  {<<"ssl_verify_fun">>, <<"FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8">>},
- {<<"tls_certificate_check">>, <<"AB57B74B1A63DC5775650699A3EC032EC0065005EFF1F020818742B7312A8426">>},
- {<<"zotonic_stdlib">>, <<"1864A96F2B5AE278DC52607F89CC90BF492713E7C3AC8EADDC1BA863E06E5921">>}]}
+ {<<"tls_certificate_check">>, <<"6CEE6CFFC35A390840D48D463541D50746A7B0E421ACAADB833CFC7961E490E7">>},
+ {<<"zotonic_stdlib">>, <<"C8651604BB9165EC4A6F9EAB1FB1A4D5BE5174C2E3D02815F76EB87CBBC495F2">>}]}
 ].

--- a/src/template_compiler_parser.yrl
+++ b/src/template_compiler_parser.yrl
@@ -55,6 +55,12 @@ Nonterminals
     CatIncludeTag
     NowTag
 
+    ComposeBlock
+    ComposeBraced
+    EndComposeBraced
+    CatComposeBlock
+    CatComposeBraced
+
     BlockBlock
     BlockBraced
     EndBlockBraced
@@ -172,10 +178,12 @@ Terminals
     block_keyword
     cache_keyword
     call_keyword
+    catcompose_keyword
     catinclude_keyword
     close_tag
     close_var
     comment_keyword
+    compose_keyword
     colon
     colons
     comma
@@ -188,6 +196,7 @@ Terminals
     endblock_keyword
     endcache_keyword
     endcomment_keyword
+    endcompose_keyword
     endfilter_keyword
     endfor_keyword
     endif_keyword
@@ -264,7 +273,7 @@ Left 500 '*' '/' '%'.
 Unary 600 Uminus Unot.
 
 %% Expected shift/reduce conflicts
-Expect 5.
+Expect 7.
 
 Template -> ExtendsTag BlockElements : {extends, '$1', '$2'}.
 Template -> OverrulesTag BlockElements : {overrules, '$2'}.
@@ -291,6 +300,8 @@ Elements -> Elements WithBlock : '$1' ++ ['$2'].
 Elements -> Elements CacheBlock : '$1' ++ ['$2'].
 Elements -> Elements ScriptBlock : '$1' ++ ['$2'].
 Elements -> Elements CommentBlock : '$1'.
+Elements -> Elements ComposeBlock : '$1' ++ ['$2'].
+Elements -> Elements CatComposeBlock : '$1' ++ ['$2'].
 % Tags
 Elements -> Elements TransTag : '$1' ++ ['$2'].
 Elements -> Elements TransExtTag : '$1' ++ ['$2'].
@@ -344,6 +355,13 @@ LibList -> LibList string_literal : '$1' ++ ['$2'].
 LoadTag -> open_tag load_keyword LoadNames close_tag : {load, '$3'}.
 LoadNames -> identifier : ['$1'].
 LoadNames -> LoadNames identifier : '$1' ++ ['$2'].
+
+ComposeBlock -> ComposeBraced BlockElements EndComposeBraced : {compose, '$1', '$2'}.
+ComposeBraced -> open_tag compose_keyword E OptWith WithArgs close_tag : {'$1', '$3', '$5'}.
+EndComposeBraced -> open_tag endcompose_keyword close_tag.
+
+CatComposeBlock -> CatComposeBraced BlockElements EndComposeBraced : {catcompose, '$1', '$2'}.
+CatComposeBraced -> open_tag catcompose_keyword E E OptWith WithArgs close_tag : {'$1', '$3', '$4', '$6'}.
 
 BlockBlock -> BlockBraced Elements EndBlockBraced : {block, '$1', '$2'}.
 BlockBraced -> open_tag block_keyword identifier close_tag : '$3'.

--- a/src/template_compiler_scanner.erl
+++ b/src/template_compiler_scanner.erl
@@ -83,6 +83,7 @@ identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc})
     Keywords = [
         <<"for">>, <<"empty">>, <<"endfor">>, <<"in">>, <<"include">>,
         <<"catinclude">>, <<"block">>, <<"endblock">>, <<"extends">>, <<"overrules">>,
+        <<"compose">>, <<"catcompose">>, <<"endcompose">>,
         <<"inherit">>, <<"autoescape">>, <<"endautoescape">>, <<"if">>, <<"else">>,
         <<"elif">>, <<"elseif">>, <<"endif">>, <<"not">>, <<"or">>, <<"and">>, <<"xor">>,
         <<"comment">>, <<"endcomment">>, <<"cycle">>, <<"firstof">>, <<"ifchanged">>,

--- a/test/template_compiler_include_SUITE.erl
+++ b/test/template_compiler_include_SUITE.erl
@@ -22,6 +22,7 @@ groups() ->
         [include_test
         ,include_dynamic_test
         ,include_args_test
+        ,compose_test
         ]}].
 
 init_per_suite(Config) ->
@@ -70,6 +71,11 @@ include_dynamic_test(_Config) ->
 include_args_test(_Config) ->
     {ok, Bin1} = template_compiler:render("include_args.tpl", #{ a => 1, b => 2 }, [], undefined),
     <<"a3:2:truec">> = iolist_to_binary(Bin1),
+    ok.
+
+compose_test(_Config) ->
+    {ok, Bin1} = template_compiler:render("compose.tpl", #{}, [], undefined),
+    <<"AxB1yC">> = iolist_to_binary(Bin1),
     ok.
 
 test_data_dir(Config) ->

--- a/test/test-data/compose.tpl
+++ b/test/test-data/compose.tpl
@@ -1,0 +1,1 @@
+A{% compose "compose_b.tpl" v=1 %}{% block a %}B{{ v }}{% endblock %}{% endcompose %}C

--- a/test/test-data/compose_b.tpl
+++ b/test/test-data/compose_b.tpl
@@ -1,0 +1,1 @@
+x{% block a %}XY{% endblock %}y


### PR DESCRIPTION
This adds the compose tag, which does an `include` but with predefined blocks.

It is like an inline definition of a template which overrules the included template.