### PR TITLE
Allow 'undefined' for include templates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24,25,26]
+        otp_version: [25,26,27]
         os: [ubuntu-latest]
 
     container:

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -201,9 +201,41 @@ block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
 
 
 %% @doc Include a template.
--spec include({File::binary(), Line::integer(), Col::integer()}, normal|optional|all,
-        template_compiler:template(), list({atom(),term()}), atom(), list(binary()), boolean(), map(), term()) ->
-        template_compiler:render_result().
+-spec include(SrcPos, Method, Template, Args, Runtime, ContextVars, IsContextVars, Vars, Context) -> Output when
+    SrcPos :: {File::binary(), Line::integer(), Col::integer()},
+    Method :: normal | optional | all,
+    Template :: template_compiler:template() | undefined,
+    Args :: list({atom(),term()}),
+    Runtime :: atom(),
+    ContextVars :: list(binary()),
+    IsContextVars :: boolean(),
+    Vars :: map(),
+    Context :: term(),
+    Output :: template_compiler:render_result().
+include(SrcPos, normal, undefined, _Args, _Runtime, _ContextVars, _IsContextVars, _Vars, _Context) ->
+    {SrcFile, SrcLine, _SrcCol} = SrcPos,
+    ?LOG_ERROR(#{
+        text => <<"Included template not found">>,
+        template => undefined,
+        srcpos => SrcPos,
+        result => error,
+        reason => enoent,
+        at => SrcFile,
+        line => SrcLine
+    }),
+    <<>>;
+include(SrcPos, _Method, undefined, _Args, _Runtime, _ContextVars, _IsContextVars, _Vars, _Context) ->
+    {SrcFile, SrcLine, _SrcCol} = SrcPos,
+    ?LOG_DEBUG(#{
+        text => <<"Included template not found">>,
+        template => undefined,
+        srcpos => SrcPos,
+        result => error,
+        reason => enoent,
+        at => SrcFile,
+        line => SrcLine
+    }),
+    <<>>;
 include(SrcPos, Method, Template, Args, Runtime, ContextVars, IsContextVars, Vars, Context) ->
     Vars1 = lists:foldl(
                 fun

--- a/test/template_compiler_include_SUITE.erl
+++ b/test/template_compiler_include_SUITE.erl
@@ -22,6 +22,7 @@ groups() ->
         [include_test
         ,include_dynamic_test
         ,include_args_test
+        ,include_undefined_test
         ,compose_test
         ,compose_inherit_test
         ]}].
@@ -72,6 +73,11 @@ include_dynamic_test(_Config) ->
 include_args_test(_Config) ->
     {ok, Bin1} = template_compiler:render("include_args.tpl", #{ a => 1, b => 2 }, [], undefined),
     <<"a3:2:truec">> = iolist_to_binary(Bin1),
+    ok.
+
+include_undefined_test(_Config) ->
+    {ok, Bin1} = template_compiler:render("include_undefined.tpl", #{ template => undefined }, [], undefined),
+    <<"ac">> = iolist_to_binary(Bin1),
     ok.
 
 compose_test(_Config) ->

--- a/test/test-data/include_undefined.tpl
+++ b/test/test-data/include_undefined.tpl
@@ -1,0 +1,1 @@
+a{% include template %}c


### PR DESCRIPTION
This prevents a crash if a template was included using a variable that evaluates to `undefined`.