### PR TITLE
Float number literals

### DIFF
--- a/src/template_compiler_expr.erl
+++ b/src/template_compiler_expr.erl
@@ -50,7 +50,11 @@ compile({trans_literal, SrcPos, {trans, _} = Tr}, #cs{runtime=Runtime} = CState,
             ]),
     {Ws, template_compiler_utils:set_pos(SrcPos, Ast)};
 compile({number_literal, _SrcPos, Nr}, _CState, Ws) ->
-    {Ws, erl_syntax:abstract(z_convert:to_integer(Nr))};
+    Number = case catch z_convert:to_integer(Nr) of
+                 {'EXIT', {badarg, _}} -> z_convert:to_float(Nr);
+                 N  -> N
+         end,
+    {Ws, erl_syntax:abstract(Number)};
 compile({atom_literal, _SrcPos, Atom}, _CState, Ws) ->
     {Ws, erl_syntax:abstract(template_compiler_utils:to_atom(Atom))};
 compile({find_value, LookupList}, CState, Ws) ->

--- a/test/template_compiler_expr_SUITE.erl
+++ b/test/template_compiler_expr_SUITE.erl
@@ -63,8 +63,6 @@ expr_test(_Config) ->
 expr_op_test(_Config) ->
     {ok, Bin1} = template_compiler:render("expr_op.tpl", #{ a => 10, b => 5 }, [], undefined),
     <<"15|5|50|5|2.0">> = iolist_to_binary(Bin1),
-    {ok, Bin2} = template_compiler:render("expr_op.tpl", #{ a => 10.0, b => 5 }, [], undefined),
-    <<"15.0|5.0|50.0|5.0|2.0">> = iolist_to_binary(Bin1),
     ok.
 
 expr_op_eq_neq_test(_Config) ->
@@ -96,7 +94,7 @@ undefined
 <<104,101,108,108,111,32,119,111,114,108,100>>
 atom
 [a,b,c]
-#{<<97>> => 1,<<98>> => 2}">> = iolist_to_binary(Bin1),
+#{<<97>> => 1,<<98>> => 2,<<99>> => 3.14159}">> = iolist_to_binary(Bin1),
     ok.
 
 expr_nested(_Config) ->

--- a/test/template_compiler_expr_SUITE.erl
+++ b/test/template_compiler_expr_SUITE.erl
@@ -90,6 +90,7 @@ expr_literals(_Config) ->
 false
 undefined
 42
+1.61803
 <<104,101,108,108,111,32,119,111,114,108,100>>
 atom
 [a,b,c]

--- a/test/template_compiler_expr_SUITE.erl
+++ b/test/template_compiler_expr_SUITE.erl
@@ -63,6 +63,8 @@ expr_test(_Config) ->
 expr_op_test(_Config) ->
     {ok, Bin1} = template_compiler:render("expr_op.tpl", #{ a => 10, b => 5 }, [], undefined),
     <<"15|5|50|5|2.0">> = iolist_to_binary(Bin1),
+    {ok, Bin2} = template_compiler:render("expr_op.tpl", #{ a => 10.0, b => 5 }, [], undefined),
+    <<"15.0|5.0|50.0|5.0|2.0">> = iolist_to_binary(Bin1),
     ok.
 
 expr_op_eq_neq_test(_Config) ->

--- a/test/test-data/literals.tpl
+++ b/test/test-data/literals.tpl
@@ -6,4 +6,4 @@
 {{ "hello world" | template_compiler_test:"w" }}
 {{ `atom` | template_compiler_test:"w" }}
 {{ [`a`, `b`, `c`] | template_compiler_test:"w" }}
-{{ %{ a : 1, b: 2 } | template_compiler_test:"w" }}
+{{ %{ a : 1, b: 2, c: 3.14159 } | template_compiler_test:"w" }}

--- a/test/test-data/literals.tpl
+++ b/test/test-data/literals.tpl
@@ -2,6 +2,7 @@
 {{ false | template_compiler_test:"w" }}
 {{ undefined | template_compiler_test:"w" }}
 {{ 42 | template_compiler_test:"w" }}
+{{ 1.61803 | template_compiler_test:"w" }}
 {{ "hello world" | template_compiler_test:"w" }}
 {{ `atom` | template_compiler_test:"w" }}
 {{ [`a`, `b`, `c`] | template_compiler_test:"w" }}


### PR DESCRIPTION
Adds simple floating point numbers, like `3.14`, as number literal.