### PR TITLE
Fix a problem where having duplicated blocks could result in endless recursion

### DIFF
--- a/test/template_compiler_basic_SUITE.erl
+++ b/test/template_compiler_basic_SUITE.erl
@@ -23,6 +23,7 @@ groups() ->
         ,hello_world_block2_test
         ,hello_world_block3_test
         ,hello_world_comment_test
+        ,block_nested_error_test
         ,block_render_test
         ,raw_test
         ]}].
@@ -70,6 +71,10 @@ hello_world_block3_test(_Config) ->
 hello_world_comment_test(_Config) ->
     {ok, Bin} = template_compiler:render("hello_world_comment.tpl", #{}, [], undefined),
     <<"Hello World!">> = iolist_to_binary(Bin),
+    ok.
+
+block_nested_error_test(_Config) ->
+    {error, {duplicate_block, <<"main">>}} = template_compiler:render("block_nested_error.tpl", #{}, [], undefined),
     ok.
 
 block_render_test(_Config) ->

--- a/test/test-data/block_nested_error.tpl
+++ b/test/test-data/block_nested_error.tpl
@@ -1,0 +1,9 @@
+{% block main %}
+    Hallo
+    {% block test %}
+        Daar
+        {% block main %}
+            oops - a block with the same name
+        {% endblock %}
+    {% endblock %}
+{% endblock%}


### PR DESCRIPTION
If a nested block was called the same as an outer block then rendering the template would result in endless recursion.

Fixed by returning an error if a block contains multiple declarations of the same block name.