### PR TITLE
Add fragments, and add arguments for extends/inherit

### DIFF
--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -820,7 +820,6 @@ block_elements({with, _, Elts}) -> Elts;
 block_elements({cache, _, Elts}) -> Elts;
 block_elements({javascript, _, Elts}) -> Elts;
 block_elements({filter, _, Elts}) -> Elts;
-block_elements({useblock, _, _, Elts}) -> Elts;
 block_elements(_) -> [].
 
 

--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -548,6 +548,7 @@ cs(Module, Filename, Options, Context, EnabledDebugPoints) ->
     #cs{
         filename=Filename,
         module=Module,
+        block_owner=Module,
         runtime=get_option(runtime, Options),
         context_vars=get_option(context_vars, Options),
         enabled_debug_points=EnabledDebugPoints,

--- a/src/template_compiler.erl
+++ b/src/template_compiler.erl
@@ -40,7 +40,8 @@
     is_enabled_debug_points/1,
     is_template_module/1,
     translations/1,
-    compile_blocks/2
+    compile_blocks/2,
+    namespace_fragment_blocks/2
     ]).
 
 -include_lib("syntax_tools/include/merl.hrl").
@@ -124,20 +125,20 @@ render(Template0, BlockMap0, Vars, Options, Context) when is_map(Vars) ->
     Template = normalize_template(Template0),
     Runtime = proplists:get_value(runtime, Options1, template_compiler_runtime),
     case block_lookup(Runtime:map_template(Template, Vars, Context), BlockMap0, [], [], Options1, Vars, Runtime, Context) of
-        {ok, BaseModule, ExtendsStack, BlockMap, OptDebugWrap} ->
+        {ok, BaseModule, ExtendsStack, BlockMap, OptDebugWrap, VarsResolved, ContextResolved} ->
             % Start with the render function of the "base" template
             % Optionally add the unique prefix for this rendering.
             Vars1 = case BaseModule:is_autoid()
                         orelse lists:any(fun(M) -> M:is_autoid() end, ExtendsStack)
                     of
                         true ->
-                            Vars#{
+                            VarsResolved#{
                                 '$autoid' => template_compiler_runtime_internal:unique()
                             };
                         false ->
-                            Vars
+                            VarsResolved
                     end,
-            {ok, maybe_wrap(BaseModule:render(Vars1, BlockMap, Context), OptDebugWrap)};
+            {ok, maybe_wrap(BaseModule:render(Vars1, BlockMap, ContextResolved), OptDebugWrap)};
         {error, {Loc, template_compiler_parser, S}} ->
             {error, {Loc, template_compiler_parser, iolist_to_binary(S)}};
         {error, _} = Error ->
@@ -158,20 +159,20 @@ render_block(Block, Template0, Vars, Options, Context) when is_map(Vars) ->
     Template = normalize_template(Template0),
     Runtime = proplists:get_value(runtime, Options1, template_compiler_runtime),
     case block_lookup(Runtime:map_template(Template, Vars, Context), #{}, [], [], Options1, Vars, Runtime, Context) of
-        {ok, BaseModule, ExtendsStack, BlockMap, _OptDebugWrap} ->
+        {ok, BaseModule, ExtendsStack, BlockMap, _OptDebugWrap, VarsResolved, ContextResolved} ->
             % Optionally add the unique prefix for this rendering.
             Vars1 = case BaseModule:is_autoid()
                         orelse lists:any(fun(M) -> M:is_autoid() end, ExtendsStack)
                     of
                         true ->
-                            Vars#{
+                            VarsResolved#{
                                 '$autoid' => template_compiler_runtime_internal:unique()
                             };
                         false ->
-                            Vars
+                            VarsResolved
                     end,
             % Render the specific block
-            {ok, template_compiler_runtime_internal:block_call({<<>>,1,1}, Block, Vars1, BlockMap, Runtime, Context)};
+            {ok, template_compiler_runtime_internal:block_call({<<>>,1,1}, Block, Vars1, BlockMap, Runtime, ContextResolved)};
         {error, {Loc, template_compiler_parser, S}} ->
             {error, {Loc, template_compiler_parser, iolist_to_binary(S)}};
         {error, _} = Error ->
@@ -277,24 +278,24 @@ block_lookup({ok, TplFile}, BlockMap, ExtendsStack, DebugTrace, Options, Vars, R
                 false ->
                     % Check extended/overruled templates (build block map)
                     BlockMap1 = add_blocks(Module:blocks(), Module, BlockMap),
-                    case Module:extends() of
-                        undefined ->
-                            {ok, Module, ExtendsStack, BlockMap1, [Trace|DebugTrace]};
-                        overrules ->
+                    case Module:extends_runtime(Vars, Context) of
+                        {undefined, Vars1, Context1} ->
+                            {ok, Module, ExtendsStack, BlockMap1, [Trace|DebugTrace], Vars1, Context1};
+                        {overrules, Vars1, Context1} ->
                             Options1 = [
                                 {trace_position, {TplFilename, 0, 0}}
                                 | lists:keydelete(trace_position, 1, Options)
                             ],
                             Template = TplFile#template_file.template,
-                            Next = Runtime:map_template({overrules, Template, Module:filename()}, Vars, Context),
-                            block_lookup(Next, BlockMap1, [Module|ExtendsStack], [Trace|DebugTrace], Options1, Vars, Runtime, Context);
-                        Extends when is_binary(Extends) ->
+                            Next = Runtime:map_template({overrules, Template, Module:filename()}, Vars1, Context1),
+                            block_lookup(Next, BlockMap1, [Module|ExtendsStack], [Trace|DebugTrace], Options1, Vars1, Runtime, Context1);
+                        {Extends, Vars1, Context1} when is_binary(Extends) ->
                             Options1 = [
                                 {trace_position, {TplFilename, 0, 0}}
                                 | lists:keydelete(trace_position, 1, Options)
                             ],
-                            Next = Runtime:map_template(Extends, Vars, Context),
-                            block_lookup(Next, BlockMap1, [Module|ExtendsStack], [Trace|DebugTrace], Options1, Vars, Runtime, Context)
+                            Next = Runtime:map_template(Extends, Vars1, Context1),
+                            block_lookup(Next, BlockMap1, [Module|ExtendsStack], [Trace|DebugTrace], Options1, Vars1, Runtime, Context1)
                     end
             end;
         {error, _} = Error ->
@@ -528,10 +529,10 @@ compile_binary_1(Module, Filename, Mtime, Runtime, ContentChecksum, EnabledDebug
             cs(Module, Filename, Options, Context, EnabledDebugPoints),
             Options)
     of
-        {ok, {Extends, Includes, BlockAsts, TemplateAst, IsAutoid, DebugPoints}} ->
+        {ok, {Extends, ExtendsRuntimeAst, Includes, BlockAsts, TemplateAst, IsAutoid, DebugPoints}} ->
             Forms = template_compiler_module:compile(
                                 Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime,
-                                Extends, Includes, BlockAsts, {TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugPoints}),
+                                {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, {TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugPoints}),
             case compile_forms(Filename, Forms) of
                 {ok, CompiledModule} = Ok ->
                     ok = template_compiler_admin:register(Filename, Options, Context, CompiledModule),
@@ -553,19 +554,23 @@ cs(Module, Filename, Options, Context, EnabledDebugPoints) ->
         context=Context
     }.
 
-compile_tokens({ok, {extends, {string_literal, _, Extend}, Elements}}, CState, _Options) ->
+compile_tokens({ok, {extends, {_TagPos, {string_literal, _, Extend}, ExtendsArgs}, Elements}}, CState, _Options) ->
     case find_blocks(Elements) of
         {ok, Blocks} ->
             {Ws, BlockAsts} = compile_blocks(Blocks, CState),
-            {ok, {Extend, Ws#ws.includes, BlockAsts, undefined, Ws#ws.is_autoid_var, collect_debug_points(undefined, BlockAsts)}};
+            {Ws1, ExtendsRuntimeAst} = compile_extends_runtime_ast(Extend, ExtendsArgs, CState),
+            Ws2 = merge_ws(Ws, Ws1),
+            {ok, {Extend, ExtendsRuntimeAst, Ws2#ws.includes, BlockAsts, undefined, Ws2#ws.is_autoid_var, collect_debug_points(undefined, BlockAsts)}};
         {error, _} = Error ->
             Error
     end;
-compile_tokens({ok, {overrules, Elements}}, CState, _Options) ->
+compile_tokens({ok, {overrules, {_TagPos, OverrulesArgs}, Elements}}, CState, _Options) ->
     case find_blocks(Elements) of
         {ok, Blocks} ->
             {Ws, BlockAsts} = compile_blocks(Blocks, CState),
-            {ok, {overrules, Ws#ws.includes, BlockAsts, undefined, Ws#ws.is_autoid_var, collect_debug_points(undefined, BlockAsts)}};
+            {Ws1, ExtendsRuntimeAst} = compile_extends_runtime_ast(overrules, OverrulesArgs, CState),
+            Ws2 = merge_ws(Ws, Ws1),
+            {ok, {overrules, ExtendsRuntimeAst, Ws2#ws.includes, BlockAsts, undefined, Ws2#ws.is_autoid_var, collect_debug_points(undefined, BlockAsts)}};
         {error, _} = Error ->
             Error
     end;
@@ -575,7 +580,7 @@ compile_tokens({ok, {base, Elements}}, CState, _Options) ->
             {Ws, BlockAsts} = compile_blocks(Blocks, CState),
             CStateElts = CState#cs{blocks = BlockAsts},
             {Ws1, TemplateAsts} = template_compiler_element:compile(Elements, CStateElts, Ws),
-            {ok, {undefined, Ws1#ws.includes, BlockAsts, TemplateAsts, Ws1#ws.is_autoid_var, collect_debug_points(Ws1, BlockAsts)}};
+            {ok, {undefined, default_extends_runtime_ast(undefined, CState), Ws1#ws.includes, BlockAsts, TemplateAsts, Ws1#ws.is_autoid_var, collect_debug_points(Ws1, BlockAsts)}};
         {error, _} = Error ->
             Error
     end;
@@ -609,6 +614,124 @@ compile_tokens({error, {Loc, template_compiler_parser, Msg}}, #cs{ filename = Fi
 compile_tokens({error, _} = Error, _CState, _Options) ->
     Error.
 
+default_extends_runtime_ast(Extends, CState) ->
+    erl_syntax:tuple([
+        erl_syntax:abstract(Extends),
+        erl_syntax:variable(CState#cs.vars_var),
+        erl_syntax:variable(CState#cs.context_var)
+    ]).
+
+compile_extends_runtime_ast(Extends, [], CState) ->
+    {#ws{}, default_extends_runtime_ast(Extends, CState)};
+compile_extends_runtime_ast(Extends, Args, CState) ->
+    {Ws1, ArgsList} = compile_with_args(Args, CState, #ws{}),
+    VarsVarName = "VarsExtends",
+    VarsAst = erl_syntax:map_expr(
+        erl_syntax:variable(CState#cs.vars_var),
+        [ erl_syntax:map_field_assoc(WName, WExpr) || {WName, WExpr} <- ArgsList ]),
+    PrefixAsts = [
+        erl_syntax:match_expr(
+            erl_syntax:variable(VarsVarName),
+            VarsAst)
+    ],
+    case is_context_vars_arg(Args, CState) of
+        true ->
+            ContextVarName = "ContextExtends",
+            ContextAst = erl_syntax:application(
+                erl_syntax:atom(CState#cs.runtime),
+                erl_syntax:atom(set_context_vars),
+                [
+                    erl_syntax:variable(VarsVarName),
+                    erl_syntax:variable(CState#cs.context_var)
+                ]),
+            Ast = erl_syntax:block_expr(
+                PrefixAsts ++
+                [
+                    erl_syntax:match_expr(
+                        erl_syntax:variable(ContextVarName),
+                        ContextAst),
+                    erl_syntax:tuple([
+                        erl_syntax:abstract(Extends),
+                        erl_syntax:variable(VarsVarName),
+                        erl_syntax:variable(ContextVarName)
+                    ])
+                ]),
+            {Ws1, Ast};
+        false ->
+            Ast = erl_syntax:block_expr(
+                PrefixAsts ++
+                [
+                    erl_syntax:tuple([
+                        erl_syntax:abstract(Extends),
+                        erl_syntax:variable(VarsVarName),
+                        erl_syntax:variable(CState#cs.context_var)
+                    ])
+                ]),
+            {Ws1, Ast}
+    end.
+
+compile_with_args(With, CState, Ws) ->
+    lists:foldl(
+        fun
+            ({Ident, true}, {WsAcc, Acc}) ->
+                VarAst = erl_syntax:atom(ident_as_atom(Ident)),
+                {WsAcc, [{VarAst, erl_syntax:atom(true)}|Acc]};
+            ({Ident, Expr}, {WsAcc, Acc}) ->
+                {Ws1, ExprAst} = template_compiler_expr:compile(Expr, CState, WsAcc),
+                VarAst = erl_syntax:atom(ident_as_atom(Ident)),
+                {Ws1, [{VarAst, ExprAst}|Acc]}
+        end,
+        {Ws, []},
+        With).
+
+is_context_vars_arg(Args, CState) when is_list(Args) ->
+    lists:any(
+        fun
+            ({{identifier, _, Ident}, _Val}) ->
+                lists:member(Ident, CState#cs.context_vars)
+        end,
+        Args).
+
+ident_as_atom({identifier, _SrcPos, Ident}) ->
+    template_compiler_utils:to_atom(Ident).
+
+merge_ws(WsA, WsB) ->
+    WsA#ws{
+        nr = erlang:max(WsA#ws.nr, WsB#ws.nr),
+        custom_tags = WsA#ws.custom_tags ++ WsB#ws.custom_tags,
+        is_forloop_var = WsA#ws.is_forloop_var orelse WsB#ws.is_forloop_var,
+        is_autoid_var = WsA#ws.is_autoid_var orelse WsB#ws.is_autoid_var,
+        includes = WsA#ws.includes ++ WsB#ws.includes,
+        debug_points = WsA#ws.debug_points ++ WsB#ws.debug_points
+    }.
+
+namespace_fragment_blocks(FragmentName, Elements) ->
+    [ namespace_fragment_element(FragmentName, E) || E <- Elements ].
+
+namespace_fragment_element(FragmentName, {block, {identifier, Pos, Name}, Elts}) ->
+    {block, {identifier, Pos, namespaced_fragment_block_name(FragmentName, Name)}, namespace_fragment_blocks(FragmentName, Elts)};
+namespace_fragment_element(FragmentName, {for, Expr, Loop, Empty}) ->
+    {for, Expr, namespace_fragment_blocks(FragmentName, Loop), namespace_fragment_blocks(FragmentName, Empty)};
+namespace_fragment_element(FragmentName, {'if', Expr, If, Else}) ->
+    {'if', Expr, namespace_fragment_blocks(FragmentName, If), namespace_fragment_blocks(FragmentName, Else)};
+namespace_fragment_element(FragmentName, {spaceless, Expr, Elts}) ->
+    {spaceless, Expr, namespace_fragment_blocks(FragmentName, Elts)};
+namespace_fragment_element(FragmentName, {autoescape, Expr, Elts}) ->
+    {autoescape, Expr, namespace_fragment_blocks(FragmentName, Elts)};
+namespace_fragment_element(FragmentName, {with, Expr, Elts}) ->
+    {with, Expr, namespace_fragment_blocks(FragmentName, Elts)};
+namespace_fragment_element(FragmentName, {cache, Expr, Elts}) ->
+    {cache, Expr, namespace_fragment_blocks(FragmentName, Elts)};
+namespace_fragment_element(FragmentName, {javascript, Expr, Elts}) ->
+    {javascript, Expr, namespace_fragment_blocks(FragmentName, Elts)};
+namespace_fragment_element(FragmentName, {filter, Expr, Elts}) ->
+    {filter, Expr, namespace_fragment_blocks(FragmentName, Elts)};
+namespace_fragment_element(_FragmentName, Element) ->
+    Element.
+
+namespaced_fragment_block_name(FragmentName, Name) ->
+    <<FragmentName/binary, "$", Name/binary>>.
+
 split_loc({Filename, Line, Col}) ->
     #{
         at => Filename,
@@ -641,6 +764,11 @@ compile_blocks(Blocks, CState) ->
 %% @doc Compile a block definition to a function name and its body elements.
 -spec compile_block(block_element(), #cs{}, #ws{}) -> {#ws{}, {atom(), erl_syntax:syntaxTree(), #ws{}}}.
 compile_block({block, {identifier, _Pos, Name}, Elts}, CState, Ws) ->
+    compile_named_block(Name, Elts, CState, Ws);
+compile_block({fragment, {identifier, _Pos, Name}, Elts}, CState, Ws) ->
+    compile_named_block(Name, Elts, CState, Ws).
+
+compile_named_block(Name, Elts, CState, Ws) ->
     BlockName = template_compiler_utils:to_atom(Name),
     {Ws1, Body} = template_compiler_element:compile(Elts, CState#cs{block=BlockName}, reset_block_ws(Ws)),
     {Ws1, {BlockName, Body, Ws1}}.
@@ -663,19 +791,26 @@ find_blocks([B|Bs], Acc, Stack) ->
             Error
     end;
 find_blocks({block, {identifier, _Pos, Name}, Elements} = Block, Acc, Stack) ->
+    find_named_block(Name, Elements, Block, Acc, Stack);
+find_blocks({fragment, {identifier, _Pos, Name}, Elements} = Fragment, Acc, Stack) ->
+    Elements1 = namespace_fragment_blocks(Name, Elements),
+    find_named_block(Name, Elements1, setelement(3, Fragment, Elements1), Acc, Stack);
+find_blocks(Element, Acc, Stack) ->
+    find_blocks(block_elements(Element), Acc, Stack).
+
+find_named_block(Name, Elements, NamedBlock, Acc, Stack) ->
     case lists:member(Name, Stack) of
         true ->
             {error, {duplicate_nested_block, Name}};
         false ->
-            Acc1 = [ Block | Acc ],
+            Acc1 = [ NamedBlock | Acc ],
             Stack1 = [ Name | Stack ],
             find_blocks(Elements, Acc1, Stack1)
-    end;
-find_blocks(Element, Acc, Stack) ->
-    find_blocks(block_elements(Element), Acc, Stack).
+    end.
 
 block_elements({compose, _, Elts}) -> Elts;
 block_elements({catcompose, _, Elts}) -> Elts;
+block_elements({fragment, _, Elts}) -> Elts;
 block_elements({for, _, Loop, Empty}) -> [Loop,Empty];
 block_elements({'if', _, If, Else}) -> [If, Else];
 block_elements({spaceless, _, Elts}) -> Elts;
@@ -684,6 +819,7 @@ block_elements({with, _, Elts}) -> Elts;
 block_elements({cache, _, Elts}) -> Elts;
 block_elements({javascript, _, Elts}) -> Elts;
 block_elements({filter, _, Elts}) -> Elts;
+block_elements({useblock, _, _, Elts}) -> Elts;
 block_elements(_) -> [].
 
 

--- a/src/template_compiler_element.erl
+++ b/src/template_compiler_element.erl
@@ -891,11 +891,13 @@ compile_use(SrcPos, Name, Args, BodyElts, CState, Ws) ->
                 "template_compiler_runtime_internal:merge_blocks("
                     "_@block_list,"
                     "_@owner,"
+                    "_@trace_module,"
                     "_@block_fun,"
                     "_@blocks)",
                 [
                     {block_list, BlockListAst},
                     {owner, erl_syntax:abstract(CallerOwner)},
+                    {trace_module, erl_syntax:atom(CState#cs.module)},
                     {block_fun, BlockFunAst},
                     {blocks, erl_syntax:variable("Blocks")}
                 ]),

--- a/src/template_compiler_element.erl
+++ b/src/template_compiler_element.erl
@@ -157,7 +157,7 @@ compile({fragment, _Ident, _Elts}, _CState, Ws) ->
     {Ws, erl_syntax:abstract(<<>>)};
 compile({inherit, {_, _SrcPos, _}, _Args}, #cs{block=undefined}, Ws) ->
     {Ws, erl_syntax:abstract(<<>>)};
-compile({inherit, {_, SrcPos, _}, Args}, #cs{block=Block, module=Module} = CState, Ws) ->
+compile({inherit, {_, SrcPos, _}, Args}, #cs{block=Block, block_owner=BlockOwner} = CState, Ws) ->
     {Ws1, ArgsList} = with_args(Args, CState, Ws, false),
     IsContextVar = is_context_vars_arg(Args, CState),
     {Ws2, _CState1, PrefixAst, VarsVarName, ContextVarName} =
@@ -167,7 +167,7 @@ compile({inherit, {_, SrcPos, _}, Args}, #cs{block=Block, module=Module} = CStat
         erl_syntax:atom(block_inherit),
         [
             erl_syntax:abstract(SrcPos),
-            erl_syntax:abstract(Module),
+            erl_syntax:abstract(BlockOwner),
             erl_syntax:atom(Block),
             erl_syntax:variable(VarsVarName),
             erl_syntax:variable("Blocks"),
@@ -877,8 +877,8 @@ compile_use(SrcPos, Name, Args, BodyElts, CState, Ws) ->
             CallerBlocks = template_compiler:namespace_fragment_blocks(
                 Name,
                 [ Block || {block, _, _} = Block <- Elts ]),
-            CallerModule = {useblock, Name, SrcPos},
-            {_BlocksWs, BlocksAsts} = template_compiler:compile_blocks(CallerBlocks, CState#cs{module=CallerModule}),
+            CallerOwner = {useblock, Name, SrcPos},
+            {_BlocksWs, BlocksAsts} = template_compiler:compile_blocks(CallerBlocks, CState#cs{block_owner=CallerOwner}),
             BlockClauses = [
                 ?Q("(_@BlockName@, Vars, Blocks, Context) -> _@BlockAst")
                 || {BlockName, BlockAst, _BlockWs} <- BlocksAsts
@@ -890,12 +890,12 @@ compile_use(SrcPos, Name, Args, BodyElts, CState, Ws) ->
             BlockMapAst = ?Q(
                 "template_compiler_runtime_internal:merge_blocks("
                     "_@block_list,"
-                    "_@module,"
+                    "_@owner,"
                     "_@block_fun,"
                     "_@blocks)",
                 [
                     {block_list, BlockListAst},
-                    {module, erl_syntax:abstract(CallerModule)},
+                    {owner, erl_syntax:abstract(CallerOwner)},
                     {block_fun, BlockFunAst},
                     {blocks, erl_syntax:variable("Blocks")}
                 ]),

--- a/src/template_compiler_element.erl
+++ b/src/template_compiler_element.erl
@@ -153,22 +153,29 @@ compile({block, {identifier, SrcPos, Name}, _Elts}, CState, Ws) ->
     {value, {BlockName, _Tree, BlockWs}} = lists:keysearch(BlockName, 1, CState#cs.blocks),
     Ws1 = Ws#ws{is_forloop_var = Ws#ws.is_forloop_var or BlockWs#ws.is_forloop_var},
     maybe_debug_element(SrcPos, template_compiler_utils:set_pos(SrcPos, Ast), CState, Ws1);
-compile({inherit, {_, _SrcPos, _}}, #cs{block=undefined}, Ws) ->
+compile({fragment, _Ident, _Elts}, _CState, Ws) ->
     {Ws, erl_syntax:abstract(<<>>)};
-compile({inherit, {_, SrcPos, _}}, #cs{block=Block, module=Module} = CState, Ws) ->
-    Ast = erl_syntax:application(
-            erl_syntax:atom(template_compiler_runtime_internal),
-            erl_syntax:atom(block_inherit),
-            [
-                erl_syntax:abstract(SrcPos),
-                erl_syntax:atom(Module),
-                erl_syntax:atom(Block),
-                erl_syntax:variable(CState#cs.vars_var),
-                erl_syntax:variable("Blocks"),
-                erl_syntax:atom(CState#cs.runtime),
-                erl_syntax:variable(CState#cs.context_var)
-            ]),
-    maybe_debug_element(SrcPos, template_compiler_utils:set_pos(SrcPos, Ast), CState, Ws#ws{is_forloop_var=true});
+compile({inherit, {_, _SrcPos, _}, _Args}, #cs{block=undefined}, Ws) ->
+    {Ws, erl_syntax:abstract(<<>>)};
+compile({inherit, {_, SrcPos, _}, Args}, #cs{block=Block, module=Module} = CState, Ws) ->
+    {Ws1, ArgsList} = with_args(Args, CState, Ws, false),
+    IsContextVar = is_context_vars_arg(Args, CState),
+    {Ws2, _CState1, PrefixAst, VarsVarName, ContextVarName} =
+        use_setup_ast(SrcPos, ArgsList, IsContextVar, CState, Ws1),
+    Ast0 = erl_syntax:application(
+        erl_syntax:atom(template_compiler_runtime_internal),
+        erl_syntax:atom(block_inherit),
+        [
+            erl_syntax:abstract(SrcPos),
+            erl_syntax:abstract(Module),
+            erl_syntax:atom(Block),
+            erl_syntax:variable(VarsVarName),
+            erl_syntax:variable("Blocks"),
+            erl_syntax:atom(CState#cs.runtime),
+            erl_syntax:variable(ContextVarName)
+        ]),
+    Ast = maybe_wrap_use_ast(SrcPos, PrefixAst, template_compiler_utils:set_pos(SrcPos, Ast0)),
+    maybe_debug_element(SrcPos, Ast, CState, Ws2#ws{is_forloop_var=true});
 compile({'include', TagPos, Method, Template, Args}, CState, Ws) ->
     {Ws1, ArgsList} = with_args(Args, CState, Ws, false),
     IsContextVar = is_context_vars_arg(Args, CState),
@@ -213,6 +220,10 @@ compile({'call_with', {identifier, SrcPos, Name}, Expr}, CState, Ws) ->
             {context, erl_syntax:variable(CState#cs.context_var)}
         ]),
     maybe_debug_element(SrcPos, Ast, CState, Ws1);
+compile({use, {identifier, SrcPos, Name}, Args}, CState, Ws) ->
+    compile_use(SrcPos, Name, Args, undefined, CState, Ws);
+compile({useblock, {identifier, SrcPos, Name}, Args, Elts}, CState, Ws) ->
+    compile_use(SrcPos, Name, Args, Elts, CState, Ws);
 compile({'compose', {TagPos, Template, Args}, Blocks}, CState, Ws) ->
     {Ws1, ArgsList} = with_args(Args, CState, Ws, false),
     IsContextVar = is_context_vars_arg(Args, CState),
@@ -843,6 +854,143 @@ catcompose({_, SrcPos, _}, Template, IdAst, ArgsList, IsContextVars, Blocks, #cs
         ]),
     Ws2 = maybe_add_include(Template, undefined, false, Ws1),
     maybe_debug_element(SrcPos, Ast, CState, Ws2).
+
+
+compile_use(SrcPos, Name, Args, BodyElts, CState, Ws) ->
+    {Ws1, ArgsList} = with_args(Args, CState, Ws, false),
+    IsContextVar = is_context_vars_arg(Args, CState),
+    FragmentName = template_compiler_utils:to_atom(Name),
+    {Ws2, CState1, PrefixAst, VarsVarName, ContextVarName} =
+        use_setup_ast(SrcPos, ArgsList, IsContextVar, CState, Ws1),
+    case BodyElts of
+        undefined ->
+            CallAst = use_block_call_ast(
+                SrcPos,
+                FragmentName,
+                erl_syntax:variable(VarsVarName),
+                erl_syntax:variable("Blocks"),
+                ContextVarName,
+                CState),
+            Ast = maybe_wrap_use_ast(SrcPos, PrefixAst, CallAst),
+            maybe_debug_element(SrcPos, Ast, CState, merge_fragment_ws(FragmentName, Ws2, CState));
+        Elts ->
+            CallerBlocks = template_compiler:namespace_fragment_blocks(
+                Name,
+                [ Block || {block, _, _} = Block <- Elts ]),
+            CallerModule = {useblock, Name, SrcPos},
+            {_BlocksWs, BlocksAsts} = template_compiler:compile_blocks(CallerBlocks, CState#cs{module=CallerModule}),
+            BlockClauses = [
+                ?Q("(_@BlockName@, Vars, Blocks, Context) -> _@BlockAst")
+                || {BlockName, BlockAst, _BlockWs} <- BlocksAsts
+            ] ++ [
+                ?Q("(_BlockName, _Vars, _Blocks, _Context) -> <<>>")
+            ],
+            BlockFunAst = erl_syntax:fun_expr(BlockClauses),
+            BlockListAst = erl_syntax:abstract([ BlockName || {BlockName, _, _} <- BlocksAsts ]),
+            BlockMapAst = ?Q(
+                "template_compiler_runtime_internal:merge_blocks("
+                    "_@block_list,"
+                    "_@module,"
+                    "_@block_fun,"
+                    "_@blocks)",
+                [
+                    {block_list, BlockListAst},
+                    {module, erl_syntax:abstract(CallerModule)},
+                    {block_fun, BlockFunAst},
+                    {blocks, erl_syntax:variable("Blocks")}
+                ]),
+            {Ws3, BodyAst} = compile(
+                useblock_body_elements(Elts),
+                CState1#cs{vars_var = VarsVarName, context_var = ContextVarName},
+                Ws2),
+            VarsWithBodyAst = erl_syntax:map_expr(
+                erl_syntax:variable(VarsVarName),
+                [ erl_syntax:map_field_assoc(erl_syntax:atom('_body'), BodyAst) ]),
+            CallAst = use_block_call_ast(
+                SrcPos,
+                FragmentName,
+                VarsWithBodyAst,
+                BlockMapAst,
+                ContextVarName,
+                CState),
+            Ast = maybe_wrap_use_ast(SrcPos, PrefixAst, CallAst),
+            maybe_debug_element(SrcPos, Ast, CState, merge_fragment_ws(FragmentName, Ws3, CState))
+    end.
+
+useblock_body_elements(Elts) ->
+    [ E || E <- Elts, not is_useblock_block(E) ].
+
+is_useblock_block({block, _, _}) ->
+    true;
+is_useblock_block(_) ->
+    false.
+
+use_setup_ast(_SrcPos, [], false, CState, Ws) ->
+    {Ws, CState, undefined, CState#cs.vars_var, CState#cs.context_var};
+use_setup_ast(SrcPos, ArgsList, IsContextVar, CState, Ws) ->
+    {CState1, Ws1} = template_compiler_utils:next_vars_var(CState, Ws),
+    VarsAst = template_compiler_utils:set_pos(
+        SrcPos,
+        erl_syntax:map_expr(
+            erl_syntax:variable(CState#cs.vars_var),
+            [ erl_syntax:map_field_assoc(WName, WExpr) || {WName, WExpr} <- ArgsList ])),
+    case IsContextVar of
+        true ->
+            {CState2, Ws2} = template_compiler_utils:next_context_var(CState1, Ws1),
+            ContextAst = erl_syntax:application(
+                erl_syntax:atom(CState#cs.runtime),
+                erl_syntax:atom(set_context_vars),
+                [
+                    erl_syntax:variable(CState1#cs.vars_var),
+                    erl_syntax:variable(CState#cs.context_var)
+                ]),
+            PrefixAsts = [
+                erl_syntax:match_expr(
+                    erl_syntax:variable(CState1#cs.vars_var),
+                    VarsAst),
+                erl_syntax:match_expr(
+                    erl_syntax:variable(CState2#cs.context_var),
+                    ContextAst)
+            ],
+            {Ws2, CState2, PrefixAsts, CState1#cs.vars_var, CState2#cs.context_var};
+        false ->
+            PrefixAsts = [
+                erl_syntax:match_expr(
+                    erl_syntax:variable(CState1#cs.vars_var),
+                    VarsAst)
+            ],
+            {Ws1, CState1, PrefixAsts, CState1#cs.vars_var, CState#cs.context_var}
+    end.
+
+use_block_call_ast(SrcPos, FragmentName, VarsAst, BlockMapAst, ContextVarName, CState) ->
+    template_compiler_utils:set_pos(
+        SrcPos,
+        erl_syntax:application(
+            erl_syntax:atom(template_compiler_runtime_internal),
+            erl_syntax:atom(block_call),
+            [
+                erl_syntax:abstract(SrcPos),
+                erl_syntax:atom(FragmentName),
+                VarsAst,
+                BlockMapAst,
+                erl_syntax:atom(CState#cs.runtime),
+                erl_syntax:variable(ContextVarName)
+            ])).
+
+maybe_wrap_use_ast(_SrcPos, undefined, CallAst) ->
+    CallAst;
+maybe_wrap_use_ast(SrcPos, PrefixAst, CallAst) ->
+    template_compiler_utils:set_pos(
+        SrcPos,
+        erl_syntax:block_expr(PrefixAst ++ [CallAst])).
+
+merge_fragment_ws(FragmentName, Ws, CState) ->
+    case lists:keysearch(FragmentName, 1, CState#cs.blocks) of
+        {value, {_BlockName, _Tree, BlockWs}} ->
+            Ws#ws{is_forloop_var = Ws#ws.is_forloop_var or BlockWs#ws.is_forloop_var};
+        false ->
+            Ws
+    end.
 
 
 expr_list(ExprList, CState, Ws) ->

--- a/src/template_compiler_internal.hrl
+++ b/src/template_compiler_internal.hrl
@@ -51,7 +51,8 @@
 %% @doc State for the compiler. Also records the current block's arguments variable, and context variable.
 -record(cs, {
         filename = <<>> :: binary(),
-        module = undefined :: undefined | block_owner(),
+        module = undefined :: atom(),
+        block_owner = undefined :: undefined | block_owner(),
         block = undefined :: atom(),
         blocks = [] :: list( {atom(), erl_syntax:syntaxTree(), #ws{}} ),
         runtime = template_compiler_runtime :: atom(),

--- a/src/template_compiler_internal.hrl
+++ b/src/template_compiler_internal.hrl
@@ -23,8 +23,10 @@
                | identifier_token().
 
 -type identifier_token() :: {identifier, linecol(), binary()}.
+-type block_owner() :: atom() | {useblock, atom() | binary(), {binary(), integer(), integer()}}.
 
--type block_element() :: {block, identifier_token(), elements()}.
+-type block_element() :: {block, identifier_token(), elements()}
+                       | {fragment, identifier_token(), elements()}.
 
 -type elements() :: list( element() ).
 
@@ -49,7 +51,7 @@
 %% @doc State for the compiler. Also records the current block's arguments variable, and context variable.
 -record(cs, {
         filename = <<>> :: binary(),
-        module = undefined :: atom(),
+        module = undefined :: undefined | block_owner(),
         block = undefined :: atom(),
         blocks = [] :: list( {atom(), erl_syntax:syntaxTree(), #ws{}} ),
         runtime = template_compiler_runtime :: atom(),

--- a/src/template_compiler_module.erl
+++ b/src/template_compiler_module.erl
@@ -26,16 +26,16 @@
 
 -include_lib("syntax_tools/include/merl.hrl").
 
-compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, undefined) ->
-    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, erl_syntax:abstract(<<>>), [], #{}, false);
-compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, {undefined, DebugPoints, EnabledDebugPoints, IsDebugCompiled}) ->
-    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, erl_syntax:abstract(<<>>), DebugPoints, EnabledDebugPoints, IsDebugCompiled);
-compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, {TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugCompiled}) ->
-    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugCompiled);
-compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, TemplateAst) ->
-    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, TemplateAst, [], #{}, false).
+compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, undefined) ->
+    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, erl_syntax:abstract(<<>>), [], #{}, false);
+compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, {undefined, DebugPoints, EnabledDebugPoints, IsDebugCompiled}) ->
+    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, erl_syntax:abstract(<<>>), DebugPoints, EnabledDebugPoints, IsDebugCompiled);
+compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, {TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugCompiled}) ->
+    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugCompiled);
+compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, TemplateAst) ->
+    compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, TemplateAst, [], #{}, false).
 
-compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, Includes, BlockAsts, TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugCompiled) ->
+compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, {Extends, ExtendsRuntimeAst}, Includes, BlockAsts, TemplateAst, DebugPoints, EnabledDebugPoints, IsDebugCompiled) ->
     Now = os:timestamp(),
     BlockNames = [ BN || {BN, _Tree, _Ws} <- BlockAsts ],
     Forms1 = lists:flatten(
@@ -47,6 +47,7 @@ compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, In
                 "blocks/0,",
                 "module/0,",
                 "extends/0,",
+                "extends_runtime/2,",
                 "includes/0,",
                 "debug_points/0,",
                 "enabled_debug_points/0,",
@@ -62,6 +63,7 @@ compile(Module, Filename, Mtime, ContentChecksum, IsAutoid, Runtime, Extends, In
             "blocks() -> _@BlockNames@.",
             "module() -> _@Module@.",
             "extends() -> _@Extends@.",
+            "extends_runtime(Vars, Context) -> _@ExtendsRuntimeAst.",
             "includes() -> _@Includes@.",
             "content_checksum() -> _@ContentChecksum@.",
             "filename() -> _@Filename@.",

--- a/src/template_compiler_parser.yrl
+++ b/src/template_compiler_parser.yrl
@@ -64,6 +64,9 @@ Nonterminals
     BlockBlock
     BlockBraced
     EndBlockBraced
+    FragmentBlock
+    FragmentBraced
+    EndFragmentBraced
 
     CommentBlock
     CommentBraced
@@ -139,6 +142,8 @@ Nonterminals
 
     CallTag
     CallWithTag
+    UseTag
+    UseBlock
 
     CacheBlock
     CacheBraced
@@ -197,6 +202,7 @@ Terminals
     endcache_keyword
     endcomment_keyword
     endcompose_keyword
+    endfragment_keyword
     endfilter_keyword
     endfor_keyword
     endif_keyword
@@ -204,11 +210,13 @@ Terminals
     endifnotequal_keyword
     endjavascript_keyword
     endspaceless_keyword
+    enduseblock_keyword
     endwith_keyword
     equal
     extends_keyword
     filter_keyword
     for_keyword
+    fragment_keyword
     identifier
     if_keyword
     ifequal_keyword
@@ -238,6 +246,8 @@ Terminals
     spaceless_keyword
     string_literal
     text
+    use_keyword
+    useblock_keyword
     url_keyword
     with_keyword
     open_curly
@@ -277,11 +287,12 @@ Nonassoc 800 dot.
 Expect 7.
 
 Template -> ExtendsTag BlockElements : {extends, '$1', '$2'}.
-Template -> OverrulesTag BlockElements : {overrules, '$2'}.
+Template -> OverrulesTag BlockElements : {overrules, '$1', '$2'}.
 Template -> Elements : {base, '$1'}.
 
 BlockElements -> '$empty' : [].
 BlockElements -> BlockElements BlockBlock : '$1' ++ ['$2'].
+BlockElements -> BlockElements FragmentBlock : '$1' ++ ['$2'].
 BlockElements -> BlockElements text : '$1'.
 BlockElements -> BlockElements CommentBlock : '$1'.
 
@@ -290,6 +301,7 @@ Elements -> Elements text : '$1' ++ ['$2'].
 Elements -> Elements ValueBraced : '$1' ++ ['$2'].
 % Block elements containing other elements
 Elements -> Elements BlockBlock : '$1' ++ ['$2'].
+Elements -> Elements FragmentBlock : '$1' ++ ['$2'].
 Elements -> Elements FilterBlock : '$1' ++ ['$2'].
 Elements -> Elements ForBlock : '$1' ++ ['$2'].
 Elements -> Elements IfBlock : '$1' ++ ['$2'].
@@ -317,6 +329,8 @@ Elements -> Elements CycleTag : '$1' ++ ['$2'].
 Elements -> Elements CustomTag : '$1' ++ ['$2'].
 Elements -> Elements CallTag : '$1' ++ ['$2'].
 Elements -> Elements CallWithTag : '$1' ++ ['$2'].
+Elements -> Elements UseTag : '$1' ++ ['$2'].
+Elements -> Elements UseBlock : '$1' ++ ['$2'].
 Elements -> Elements UrlTag : '$1' ++ ['$2'].
 Elements -> Elements PrintTag : '$1' ++ ['$2'].
 Elements -> Elements ImageTag : '$1' ++ ['$2'].
@@ -330,9 +344,12 @@ ValueBraced -> open_var E OptWith close_var : {value, '$1', '$2', '$3'}.
 OptWith -> '$empty' : [].
 OptWith -> with_keyword Args : '$2'.
 
-ExtendsTag -> open_tag extends_keyword string_literal close_tag : '$3'.
-OverrulesTag -> open_tag overrules_keyword close_tag : overrules.
-InheritTag -> open_tag inherit_keyword close_tag : {inherit, '$1'}.
+ExtendsTag -> open_tag extends_keyword string_literal Args close_tag : {'$1', '$3', '$4'}.
+ExtendsTag -> open_tag extends_keyword string_literal with_keyword Args close_tag : {'$1', '$3', '$5'}.
+OverrulesTag -> open_tag overrules_keyword Args close_tag : {'$1', '$3'}.
+OverrulesTag -> open_tag overrules_keyword with_keyword Args close_tag : {'$1', '$4'}.
+InheritTag -> open_tag inherit_keyword Args close_tag : {inherit, '$1', '$3'}.
+InheritTag -> open_tag inherit_keyword with_keyword Args close_tag : {inherit, '$1', '$4'}.
 
 TransTag -> open_trans trans_text close_trans : '$2'.
 TransTag -> open_trans text close_trans : '$2'.
@@ -367,6 +384,10 @@ CatComposeBraced -> open_tag catcompose_keyword E E OptWith WithArgs close_tag :
 BlockBlock -> BlockBraced Elements EndBlockBraced : {block, '$1', '$2'}.
 BlockBraced -> open_tag block_keyword identifier close_tag : '$3'.
 EndBlockBraced -> open_tag endblock_keyword close_tag.
+
+FragmentBlock -> FragmentBraced Elements EndFragmentBraced : {fragment, '$1', '$2'}.
+FragmentBraced -> open_tag fragment_keyword identifier close_tag : '$3'.
+EndFragmentBraced -> open_tag endfragment_keyword close_tag.
 
 CommentBlock -> CommentBraced Elements EndCommentBraced.
 CommentBraced -> open_tag comment_keyword close_tag.
@@ -460,6 +481,10 @@ CustomTag -> open_tag identifier Args close_tag : {custom_tag, '$2', '$3'}.
 
 CallTag -> open_tag call_keyword identifier Args close_tag : {call, '$3', '$4'}.
 CallWithTag -> open_tag call_keyword identifier with_keyword E close_tag : {call_with, '$3', '$5'}.
+UseTag -> open_tag use_keyword identifier Args close_tag : {use, '$3', '$4'}.
+UseTag -> open_tag use_keyword identifier with_keyword Args close_tag : {use, '$3', '$5'}.
+UseBlock -> open_tag useblock_keyword identifier Args close_tag Elements open_tag enduseblock_keyword close_tag : {useblock, '$3', '$4', '$6'}.
+UseBlock -> open_tag useblock_keyword identifier with_keyword Args close_tag Elements open_tag enduseblock_keyword close_tag : {useblock, '$3', '$5', '$7'}.
 
 ImageTag -> open_tag image_keyword E Args close_tag : {image, '$2', '$3', '$4' }.
 ImageUrlTag -> open_tag image_url_keyword E Args close_tag : {image_url, '$2', '$3', '$4' }.
@@ -552,4 +577,3 @@ E -> Value : '$1'.
 
 Uminus -> '-' E : {expr, {'negate', '$1'}, '$2'}.
 Unot -> not_keyword E : {expr, {'not', '$1'}, '$2'}.
-

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -212,6 +212,17 @@ block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
                                 After
                             ]
                     end;
+                [ {TraceModule, RenderFun} | _ ] when is_atom(TraceModule), is_function(RenderFun) ->
+                    case Runtime:trace_block(SrcPos, Block, TraceModule, Context) of
+                        ok ->
+                            RenderFun(Block, Vars, BlockMap, Context);
+                        {ok, Before, After} ->
+                            [
+                                Before,
+                                RenderFun(Block, Vars, BlockMap, Context),
+                                After
+                            ]
+                    end;
                 [ {_Owner, TraceModule, RenderFun} | _ ] when is_atom(TraceModule), is_function(RenderFun) ->
                     case Runtime:trace_block(SrcPos, Block, TraceModule, Context) of
                         ok ->

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -25,7 +25,7 @@
     with_vars/3,
     block_call/6,
     block_inherit/7,
-    merge_blocks/4,
+    merge_blocks/5,
     include/9,
     compose/11,
     call/4,
@@ -155,8 +155,19 @@ block_call(SrcPos, Block, Vars, BlockMap, Runtime, Context) ->
                         After
                     ]
             end;
-        {ok, [{Module, RenderFun}|_]} when is_function(RenderFun) ->
-            case Runtime:trace_block(SrcPos, Block, Module, Context) of
+        {ok, [{TraceModule, RenderFun}|_]} when is_atom(TraceModule), is_function(RenderFun) ->
+            case Runtime:trace_block(SrcPos, Block, TraceModule, Context) of
+                ok ->
+                    RenderFun(Block, Vars, BlockMap, Context);
+                {ok, Before, After} ->
+                    [
+                        Before,
+                        RenderFun(Block, Vars, BlockMap, Context),
+                        After
+                    ]
+            end;
+        {ok, [{_Owner, TraceModule, RenderFun}|_]} when is_atom(TraceModule), is_function(RenderFun) ->
+            case Runtime:trace_block(SrcPos, Block, TraceModule, Context) of
                 ok ->
                     RenderFun(Block, Vars, BlockMap, Context);
                 {ok, Before, After} ->
@@ -178,11 +189,13 @@ block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
         {ok, Modules} ->
             case lists:dropwhile(
                     fun
+                        ({M, _TraceModule, _F}) -> M =:= Module;
                         ({M, _F}) -> M =:= Module;
                         (M) -> M =:= Module
                     end,
                     lists:dropwhile(
                         fun
+                            ({M, _TraceModule, _F}) -> M =/= Module;
                             ({M, _F}) -> M =/= Module;
                             (M) -> M =/= Module
                         end,
@@ -199,6 +212,17 @@ block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
                                 After
                             ]
                     end;
+                [ {_Owner, TraceModule, RenderFun} | _ ] when is_atom(TraceModule), is_function(RenderFun) ->
+                    case Runtime:trace_block(SrcPos, Block, TraceModule, Context) of
+                        ok ->
+                            RenderFun(Block, Vars, BlockMap, Context);
+                        {ok, Before, After} ->
+                            [
+                                Before,
+                                RenderFun(Block, Vars, BlockMap, Context),
+                                After
+                            ]
+                    end;
                 [] ->
                     <<>>
             end;
@@ -207,11 +231,11 @@ block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
             <<>>
     end.
 
-merge_blocks(BlockList, BlockModule, BlockFun, BlockMap) ->
+merge_blocks(BlockList, BlockOwner, TraceModule, BlockFun, BlockMap) ->
     lists:foldl(
         fun(Block, Acc) ->
             Existing = maps:get(Block, Acc, []),
-            Acc#{ Block => [ {BlockModule, BlockFun} | Existing ] }
+            Acc#{ Block => [ {BlockOwner, TraceModule, BlockFun} | Existing ] }
         end,
         BlockMap,
         BlockList).

--- a/src/template_compiler_runtime_internal.erl
+++ b/src/template_compiler_runtime_internal.erl
@@ -25,6 +25,7 @@
     with_vars/3,
     block_call/6,
     block_inherit/7,
+    merge_blocks/4,
     include/9,
     compose/11,
     call/4,
@@ -171,17 +172,23 @@ block_call(SrcPos, Block, Vars, BlockMap, Runtime, Context) ->
     end.
 
 %% @doc Call the block function of the template the current module extends.
--spec block_inherit({binary(), integer(), integer()}, atom(), atom(), map(), map(), atom(), term()) -> term().
+-spec block_inherit({binary(), integer(), integer()}, term(), atom(), map(), map(), atom(), term()) -> term().
 block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
     case maps:find(Block, BlockMap) of
         {ok, Modules} ->
             case lists:dropwhile(
                     fun
-                        ({M, _F}) -> M =/= Module;
-                        (M) -> M =/= Module
-                    end, Modules)
+                        ({M, _F}) -> M =:= Module;
+                        (M) -> M =:= Module
+                    end,
+                    lists:dropwhile(
+                        fun
+                            ({M, _F}) -> M =/= Module;
+                            (M) -> M =/= Module
+                        end,
+                        Modules))
             of
-                [ _Module, Next | _ ] when is_atom(Next) ->
+                [ Next | _ ] when is_atom(Next) ->
                     case Runtime:trace_block(SrcPos, Block, Next, Context) of
                         ok ->
                             Next:render_block(Block, Vars, BlockMap, Context);
@@ -199,6 +206,15 @@ block_inherit(SrcPos, Module, Block, Vars, BlockMap, Runtime, Context) ->
             % No such block, return empty data.
             <<>>
     end.
+
+merge_blocks(BlockList, BlockModule, BlockFun, BlockMap) ->
+    lists:foldl(
+        fun(Block, Acc) ->
+            Existing = maps:get(Block, Acc, []),
+            Acc#{ Block => [ {BlockModule, BlockFun} | Existing ] }
+        end,
+        BlockMap,
+        BlockList).
 
 
 %% @doc Include a template.

--- a/src/template_compiler_scanner.erl
+++ b/src/template_compiler_scanner.erl
@@ -10,7 +10,7 @@
 %%% The MIT License
 %%%
 %%% Copyright (c) 2007 Roberto Saccon, Evan Miller
-%%% Copyright (c) 2009-2020 Marc Worrell
+%%% Copyright (c) 2009-2026 Marc Worrell
 %%%
 %%% Permission is hereby granted, free of charge, to any person obtaining a copy
 %%% of this software and associated documentation files (the "Software"), to deal
@@ -84,6 +84,7 @@ identifier_to_keyword({identifier, Pos, String}, {PrevToken, Acc})
         <<"for">>, <<"empty">>, <<"endfor">>, <<"in">>, <<"include">>,
         <<"catinclude">>, <<"block">>, <<"endblock">>, <<"extends">>, <<"overrules">>,
         <<"compose">>, <<"catcompose">>, <<"endcompose">>,
+        <<"fragment">>, <<"endfragment">>, <<"use">>, <<"useblock">>, <<"enduseblock">>,
         <<"inherit">>, <<"autoescape">>, <<"endautoescape">>, <<"if">>, <<"else">>,
         <<"elif">>, <<"elseif">>, <<"endif">>, <<"not">>, <<"or">>, <<"and">>, <<"xor">>,
         <<"comment">>, <<"endcomment">>, <<"cycle">>, <<"firstof">>, <<"ifchanged">>,

--- a/test/template_compiler_basic_SUITE.erl
+++ b/test/template_compiler_basic_SUITE.erl
@@ -29,6 +29,9 @@ groups() ->
         ,block_nested_filter_error_test
         ,compile_binary_stable_module_name_test
         ,block_render_test
+        ,extends_args_test
+        ,inherit_args_test
+        ,overrules_args_test
         ,raw_test
         ]}].
 
@@ -115,6 +118,24 @@ block_render_test(_Config) ->
     <<"A">> = iolist_to_binary(BinA),
     {ok, BinB} = template_compiler:render_block(b, "block_render.tpl", #{}, [], undefined),
     <<"B">> = iolist_to_binary(BinB),
+    ok.
+
+extends_args_test(_Config) ->
+    {ok, Bin} = template_compiler:render("extends_args_child.tpl", #{}, [], undefined),
+    <<"Hello World">> = iolist_to_binary(Bin),
+    ok.
+
+inherit_args_test(_Config) ->
+    {ok, Bin} = template_compiler:render("inherit_args_child.tpl", #{}, [], undefined),
+    <<"Bye Hello World">> = iolist_to_binary(Bin),
+    ok.
+
+overrules_args_test(Config) ->
+    Filename = filename:join([test_data_dir(Config), "overrules_args.tpl"]),
+    {ok, Mod} = template_compiler:lookup(Filename, [], undefined),
+    overrules = Mod:extends(),
+    {overrules, Vars, undefined} = Mod:extends_runtime(#{}, undefined),
+    <<"World">> = maps:get(who, Vars),
     ok.
 
 raw_test(_Config) ->

--- a/test/template_compiler_fragment_SUITE.erl
+++ b/test/template_compiler_fragment_SUITE.erl
@@ -21,6 +21,7 @@ groups() ->
         [fragment_use_test
         ,fragment_useblock_test
         ,fragment_useblock_blocks_test
+        ,fragment_useblock_compose_test
         ,fragment_useblock_multiple_fragments_test
         ,fragment_debug_points_test
         ,fragment_extends_same_name_blocks_test
@@ -55,6 +56,11 @@ fragment_useblock_test(_Config) ->
 fragment_useblock_blocks_test(_Config) ->
     {ok, Bin} = template_compiler:render("fragment_useblock_blocks.tpl", #{}, [], undefined),
     <<"<section>Caller Base<div>Body</div></section>">> = iolist_to_binary(Bin),
+    ok.
+
+fragment_useblock_compose_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment_useblock_compose.tpl", #{}, [], undefined),
+    <<"<section>xB1y<div>Body</div></section>">> = iolist_to_binary(Bin),
     ok.
 
 fragment_useblock_multiple_fragments_test(_Config) ->

--- a/test/template_compiler_fragment_SUITE.erl
+++ b/test/template_compiler_fragment_SUITE.erl
@@ -1,0 +1,82 @@
+-module(template_compiler_fragment_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile(export_all).
+
+
+suite() ->
+    [
+        {timetrap, {seconds, 30}}
+    ].
+
+all() ->
+    [
+        {group, basic}
+    ].
+
+groups() ->
+    [{basic, [],
+        [fragment_use_test
+        ,fragment_useblock_test
+        ,fragment_useblock_blocks_test
+        ,fragment_useblock_multiple_fragments_test
+        ,fragment_extends_same_name_blocks_test
+        ,fragment_extends_lookup_test
+        ,fragment_extends_override_test
+        ]}].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(template_compiler),
+    application:set_env(template_compiler, template_dir, test_data_dir(Config)),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(basic, Config) ->
+    Config.
+
+end_per_group(basic, _Config) ->
+    ok.
+
+fragment_use_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment.tpl", #{}, [], undefined),
+    <<"AB[x][y]C">> = iolist_to_binary(Bin),
+    ok.
+
+fragment_useblock_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment_useblock.tpl", #{}, [], undefined),
+    <<"<div>T:Body</div>">> = iolist_to_binary(Bin),
+    ok.
+
+fragment_useblock_blocks_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment_useblock_blocks.tpl", #{}, [], undefined),
+    <<"<section>Caller Base<div>Body</div></section>">> = iolist_to_binary(Bin),
+    ok.
+
+fragment_useblock_multiple_fragments_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment_useblock_multiple.tpl", #{}, [], undefined),
+    <<"<section>A1 Base A<div>Body A</div></section><section>B1 Base B<div>Body B</div></section>">> =
+        z_string:trim(iolist_to_binary(Bin)),
+    ok.
+
+fragment_extends_same_name_blocks_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment_extends_same_name_child.tpl", #{}, [], undefined),
+    <<"<section>Caller Child Base<div>Body</div></section>">> = iolist_to_binary(Bin),
+    ok.
+
+fragment_extends_lookup_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment_extends_child.tpl", #{}, [], undefined),
+    <<"Hello child">> = iolist_to_binary(Bin),
+    ok.
+
+fragment_extends_override_test(_Config) ->
+    {ok, Bin} = template_compiler:render("fragment_extends_override_child.tpl", #{}, [], undefined),
+    <<"Hi child">> = iolist_to_binary(Bin),
+    ok.
+
+test_data_dir(Config) ->
+    filename:join([
+        filename:dirname(filename:dirname(?config(data_dir, Config))),
+        "test-data"]).

--- a/test/template_compiler_fragment_SUITE.erl
+++ b/test/template_compiler_fragment_SUITE.erl
@@ -1,6 +1,7 @@
 -module(template_compiler_fragment_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include("../include/template_compiler.hrl").
 
 -compile(export_all).
 
@@ -21,6 +22,7 @@ groups() ->
         ,fragment_useblock_test
         ,fragment_useblock_blocks_test
         ,fragment_useblock_multiple_fragments_test
+        ,fragment_debug_points_test
         ,fragment_extends_same_name_blocks_test
         ,fragment_extends_lookup_test
         ,fragment_extends_override_test
@@ -59,6 +61,28 @@ fragment_useblock_multiple_fragments_test(_Config) ->
     {ok, Bin} = template_compiler:render("fragment_useblock_multiple.tpl", #{}, [], undefined),
     <<"<section>A1 Base A<div>Body A</div></section><section>B1 Base B<div>Body B</div></section>">> =
         z_string:trim(iolist_to_binary(Bin)),
+    ok.
+
+fragment_debug_points_test(_Config) ->
+    Context = #{ trace_pid => self() },
+    {ok, #template_file{ filename = Filename }} = template_compiler_runtime:map_template(<<"fragment_debug.tpl">>, [], undefined),
+    {ok, Mod0} = template_compiler:lookup(Filename, [], Context),
+    DebugPoints = Mod0:debug_points(),
+    true = (length(DebugPoints) >= 2),
+    [_FirstPoint | _] = DebugPoints,
+    {ok, _Mod} = template_compiler:compile_file(
+        Filename,
+        [
+            {runtime, template_compiler_debug_runtime},
+            {debug_points, DebugPoints}
+        ],
+        Context),
+    {ok, Bin} = template_compiler:render(
+        "fragment_debug.tpl",
+        #{ value => 42 },
+        [{runtime, template_compiler_debug_runtime}],
+        Context),
+    <<"[42]<div>42:Body</div>">> = iolist_to_binary(Bin),
     ok.
 
 fragment_extends_same_name_blocks_test(_Config) ->

--- a/test/template_compiler_highlight_SUITE.erl
+++ b/test/template_compiler_highlight_SUITE.erl
@@ -31,6 +31,7 @@ groups() ->
         ,highlight_single_quote_include_test
         ,highlight_nav_anchor_include_test
         ,highlight_nav_anchor_extends_overrules_test
+        ,highlight_fragment_use_keywords_test
         ,highlight_escape_text_test
         ,highlight_escape_string_literal_test
         ,highlight_module_test
@@ -187,6 +188,18 @@ highlight_nav_anchor_extends_overrules_test(_Config) ->
         <<"overrules">>
     ]),
     {_, _} = binary:match(Html, <<"&quot;base.tpl&quot;">>),
+    ok.
+
+highlight_fragment_use_keywords_test(_Config) ->
+    Template = <<"{% fragment panel %}{% block title %}Base{% endblock %}{% endfragment %}{% use panel %}{% useblock panel %}{% block title %}X{% endblock %}Body{% enduseblock %}">>,
+    {ok, Html} = template_compiler:highlight_binary(Template, <<"fragment_keywords.tpl">>),
+    assert_in_order(Html, [
+        <<"<span style=\"color:#0f766e;font-weight:600;\">fragment</span>">>,
+        <<"<span style=\"color:#0f766e;font-weight:600;\">endfragment</span>">>,
+        <<"<span style=\"color:#0f766e;font-weight:600;\">use</span>">>,
+        <<"<span style=\"color:#0f766e;font-weight:600;\">useblock</span>">>,
+        <<"<span style=\"color:#0f766e;font-weight:600;\">enduseblock</span>">>
+    ]),
     ok.
 
 highlight_escape_text_test(_Config) ->

--- a/test/test-data/extends_args_child.tpl
+++ b/test/test-data/extends_args_child.tpl
@@ -1,0 +1,1 @@
+{% extends "extends_args_parent.tpl" who="World" %}{% block main %}{% inherit %}{% endblock %}

--- a/test/test-data/extends_args_parent.tpl
+++ b/test/test-data/extends_args_parent.tpl
@@ -1,0 +1,1 @@
+{% block main %}Hello {{ who }}{% endblock %}

--- a/test/test-data/fragment.tpl
+++ b/test/test-data/fragment.tpl
@@ -1,0 +1,1 @@
+A{% fragment cell %}[{{ value }}]{% endfragment %}B{% use cell value="x" %}{% use cell with value="y" %}C

--- a/test/test-data/fragment_debug.tpl
+++ b/test/test-data/fragment_debug.tpl
@@ -1,0 +1,1 @@
+{% fragment item %}[{{ value }}]{% endfragment %}{% fragment panel %}<div>{{ value }}:{{ _body }}</div>{% endfragment %}{% use item %}{% useblock panel %}Body{% enduseblock %}

--- a/test/test-data/fragment_extends_child.tpl
+++ b/test/test-data/fragment_extends_child.tpl
@@ -1,0 +1,1 @@
+{% extends "fragment_extends_parent.tpl" %}{% block main %}{% use greeting name="child" %}{% endblock %}

--- a/test/test-data/fragment_extends_override_child.tpl
+++ b/test/test-data/fragment_extends_override_child.tpl
@@ -1,0 +1,1 @@
+{% extends "fragment_extends_parent.tpl" %}{% fragment greeting %}Hi {{ name }}{% endfragment %}{% block main %}{% use greeting name="child" %}{% endblock %}

--- a/test/test-data/fragment_extends_parent.tpl
+++ b/test/test-data/fragment_extends_parent.tpl
@@ -1,0 +1,1 @@
+{% fragment greeting %}Hello {{ name }}{% endfragment %}{% block main %}{% use greeting name="parent" %}{% endblock %}

--- a/test/test-data/fragment_extends_same_name_child.tpl
+++ b/test/test-data/fragment_extends_same_name_child.tpl
@@ -1,0 +1,1 @@
+{% extends "fragment_extends_same_name_parent.tpl" %}{% fragment panel %}<section>{% block title %}Child {% inherit %}{% endblock %}<div>{{ _body }}</div></section>{% endfragment %}{% block main %}{% useblock panel %}{% block title %}Caller {% inherit %}{% endblock %}Body{% enduseblock %}{% endblock %}

--- a/test/test-data/fragment_extends_same_name_parent.tpl
+++ b/test/test-data/fragment_extends_same_name_parent.tpl
@@ -1,0 +1,1 @@
+{% fragment panel %}<section>{% block title %}Base{% endblock %}<div>{{ _body }}</div></section>{% endfragment %}{% block main %}{% useblock panel %}{% block title %}Caller {% inherit %}{% endblock %}Body{% enduseblock %}{% endblock %}

--- a/test/test-data/fragment_useblock.tpl
+++ b/test/test-data/fragment_useblock.tpl
@@ -1,0 +1,1 @@
+{% fragment panel %}<div>{{ title }}:{{ _body }}</div>{% endfragment %}{% useblock panel title="T" %}Body{% enduseblock %}

--- a/test/test-data/fragment_useblock_blocks.tpl
+++ b/test/test-data/fragment_useblock_blocks.tpl
@@ -1,0 +1,1 @@
+{% fragment panel %}<section>{% block title %}Base{% endblock %}<div>{{ _body }}</div></section>{% endfragment %}{% useblock panel %}{% block title %}Caller {% inherit %}{% endblock %}Body{% enduseblock %}

--- a/test/test-data/fragment_useblock_compose.tpl
+++ b/test/test-data/fragment_useblock_compose.tpl
@@ -1,0 +1,1 @@
+{% fragment panel %}<section>{% block title %}Base{% endblock %}<div>{{ _body }}</div></section>{% endfragment %}{% useblock panel %}{% block title %}{% compose "compose_b.tpl" v=1 %}{% block a %}B{{ v }}{% endblock %}{% endcompose %}{% endblock %}Body{% enduseblock %}

--- a/test/test-data/fragment_useblock_multiple.tpl
+++ b/test/test-data/fragment_useblock_multiple.tpl
@@ -1,0 +1,3 @@
+{% fragment panel_a %}<section>{% block title %}Base A{% endblock %}<div>{{ _body }}</div></section>{% endfragment %}
+{% fragment panel_b %}<section>{% block title %}Base B{% endblock %}<div>{{ _body }}</div></section>{% endfragment %}
+{% useblock panel_a %}{% block title %}A1 {% inherit %}{% endblock %}Body A{% enduseblock %}{% useblock panel_b %}{% block title %}B1 {% inherit %}{% endblock %}Body B{% enduseblock %}

--- a/test/test-data/inherit_args_child.tpl
+++ b/test/test-data/inherit_args_child.tpl
@@ -1,0 +1,1 @@
+{% extends "inherit_args_parent.tpl" %}{% block hello %}Bye {% inherit with who="World" %}{% endblock %}

--- a/test/test-data/inherit_args_parent.tpl
+++ b/test/test-data/inherit_args_parent.tpl
@@ -1,0 +1,1 @@
+{% block hello %}Hello {{ who }}{% endblock %}

--- a/test/test-data/overrules_args.tpl
+++ b/test/test-data/overrules_args.tpl
@@ -1,0 +1,1 @@
+{% overrules with who="World" %}{% block main %}{{ who }}{% endblock %}


### PR DESCRIPTION
This pull request introduces significant enhancements and refactoring to the template compiler, focusing on improved support for fragments, block inheritance, and dynamic extension arguments. The core logic for handling template inheritance and fragments has been generalized, and new utilities for namespacing and argument handling have been added. These changes enable more flexible and powerful template composition.

**Key changes:**

### Enhanced template inheritance and extension logic

* The inheritance mechanism now supports passing arguments (`with`-style) and context variables to extended templates via a new `extends_runtime` AST structure and supporting code, allowing for more dynamic template extension scenarios. [[1]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fL280-R298) [[2]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fL556-R573) [[3]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR617-R734) [[4]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fL531-R535) [[5]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fL578-R583)
* The `render` and `render_block` functions now propagate resolved variables and context from the inheritance chain, ensuring correct scoping and context passing throughout rendering. [[1]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fL127-R141) [[2]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fL161-R175)

### Fragment and block improvements

* Fragments are now treated similarly to blocks, with namespacing applied to avoid naming collisions; new utilities for namespacing fragment blocks and elements are introduced. [[1]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fL43-R44) [[2]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR767-R771) [[3]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR794-R813)
* The block-finding and compilation logic has been refactored to treat fragments and blocks uniformly, supporting nested and namespaced fragments. [[1]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR794-R813) [[2]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR822) [[3]](diffhunk://#diff-ad5c30ffccd4ad7e74ca5e81955161e1b878d961900744fe69ab44b7f14da9e6L156-R178)

### New and extended template features

* Support for the `{use, ...}` and `{useblock, ...}` constructs has been added, including argument handling and context variable propagation, enabling more modular and reusable templates. [[1]](diffhunk://#diff-ad5c30ffccd4ad7e74ca5e81955161e1b878d961900744fe69ab44b7f14da9e6R223-R226) [[2]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR822)
* Block inheritance (`inherit`) now supports arguments and context variables, providing more control over block content and scoping.

### Utility functions and codebase improvements

* Added helper functions for merging workspace state, compiling extension arguments, and namespacing fragment blocks, improving code clarity and maintainability.
* Internal refactoring to centralize and generalize block and fragment handling, reducing code duplication and potential for errors. [[1]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR767-R771) [[2]](diffhunk://#diff-42dfd34529068c608b811cedc616d8e3a0a3e8db9272343f81dd5aa803eeca4fR794-R813)

These changes collectively make the template compiler more robust, flexible, and extensible for complex real-world templating scenarios.